### PR TITLE
Parâmetro charset na classe Database

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -24,7 +24,8 @@
 			'host' => 'localhost',
 			'user' => 'root',
 			'password' => '',
-			'dbname' => 'hxphp'
+			'dbname' => 'hxphp',
+			'charset' => 'utf8'
 		));
 
 		$configs->env->development->mail->setFrom(array(
@@ -42,7 +43,8 @@
 			'host' => 'localhost',
 			'user' => 'usuariodobanco',
 			'password' => 'senhadobanco',
-			'dbname' => 'hxphp'
+			'dbname' => 'hxphp',
+			'charset' => 'utf8'
 		));
 
 		$configs->env->production->mail->setFrom(array(

--- a/src/HXPHP/System/App.php
+++ b/src/HXPHP/System/App.php
@@ -50,6 +50,7 @@ class App
 								.':'.$this->configs->database->password
 								.'@'.$this->configs->database->host
 								.'/'.$this->configs->database->dbname
+								.'?charset='.$this->configs->database->charset
 			)
 		);
 	}

--- a/src/HXPHP/System/Configs/Modules/Database.php
+++ b/src/HXPHP/System/Configs/Modules/Database.php
@@ -9,6 +9,7 @@ class Database
 	public $user;
 	public $password;
 	public $dbname;
+	public $charset;
 
 	public function __construct()
 	{
@@ -17,7 +18,8 @@ class Database
 			'host' => 'localhost',
 			'user' => 'root',
 			'password' => '',
-			'dbname' => 'hxphp'
+			'dbname' => 'hxphp',
+			'charset' => 'utf8'
 		));
 		return $this;
 	}
@@ -28,6 +30,7 @@ class Database
 		$this->user = $data['user'];
 		$this->password = $data['password'];
 		$this->dbname = $data['dbname'];
+		$this->charset = $data['charset'];
 
 		return $this;
 	}

--- a/src/HXPHP/System/Configs/Modules/Database.php
+++ b/src/HXPHP/System/Configs/Modules/Database.php
@@ -25,12 +25,16 @@ class Database
 	}
 	public function setConnectionData(array $data)
 	{
-		$this->driver = $data['driver'];
+		(array_key_exists('driver', $data)) ?
+                    $this->driver = $data['driver'] :
+                    $this->driver = 'mysql';
 		$this->host = $data['host'];
 		$this->user = $data['user'];
 		$this->password = $data['password'];
 		$this->dbname = $data['dbname'];
-		$this->charset = $data['charset'];
+		(array_key_exists('charset', $data)) ?
+                    $this->charset = $data['charset'] :
+                    $this->charset = 'utf8';
 
 		return $this;
 	}


### PR DESCRIPTION
Agora é possível setar o `charset` do seu banco de dados, para não ocorrer problemas com acentuação na hora de salvar os registros