### PR TITLE
Add tratamento superglobal $_SERVER

### DIFF
--- a/src/HXPHP/System/Http/Request.php
+++ b/src/HXPHP/System/Http/Request.php
@@ -138,6 +138,25 @@ class Request
 
 		return $post[$name];
 	}
+        
+        /**
+	 * Obtém os dados da superglobal $_SERVER
+	 * @param  string $name Nome do parâmetro
+	 * @return null         Retorna o array $_SERVER geral ou em um índice específico
+	 */
+        
+        public function server($name = null)
+        {
+            $server = $this->filter($_SERVER, INPUT_SERVER, $this->custom_filters);
+            
+            if(!$name)
+                return $server;
+            
+            if(!isset($server[$name]))
+                return NULL;
+            
+            return $server[$name];
+        }
 
 	/**
 	 * Retorna o método da requisição


### PR DESCRIPTION
Adicionei um método que, assim como já existe outros para tratamento das superglobais $_POST e $_GET, trata a $_SERVER, que pode ser usada agora como `$this->request->server('INDICE_DESEJADO')`