### PR TITLE
Remoção de {} que possuem apenas uma linha de comando

### DIFF
--- a/src/HXPHP/System/App.php
+++ b/src/HXPHP/System/App.php
@@ -83,9 +83,9 @@ class App
 		require_once($controllerFile);
 
 		//Verifica se a classe correspondente ao Controller existe
-		if ( ! class_exists($controller)) {
+		if ( ! class_exists($controller))
 			$controller = $notFoundController;
-		}
+
 
 		$app = new $controller($this->configs);
 

--- a/src/HXPHP/System/Configs/Config.php
+++ b/src/HXPHP/System/Configs/Config.php
@@ -19,12 +19,12 @@ class Config
 	public function __get($param) {
 		$current = $this->define->getDefault();
 
-		if (isset($this->env->$current->$param)) {
+		if (isset($this->env->$current->$param))
 			return $this->env->$current->$param;
-		}
-		else if(isset($this->global->$param)) {
+
+		else if(isset($this->global->$param)) 
 			return $this->global->$param;
-		}
+
 
 		throw new \Exception("Parametro/Modulo '$param' nao encontrado. Verifique se o ambiente definido esta configurado e os modulo utilizados registrados.", 1);
 	}

--- a/src/HXPHP/System/Configs/DefineEnvironment.php
+++ b/src/HXPHP/System/Configs/DefineEnvironment.php
@@ -10,13 +10,11 @@ class DefineEnvironment
 	{
 		$server_name = $_SERVER['SERVER_NAME'];
 		$development = new Environments\EnvironmentDevelopment;
-	
-		if (in_array($server_name, $development->servers)) {
-			$this->currentEnviroment = 'development';
-		}
-		else {
+
+		(in_array($server_name, $development->servers)) ?
+			$this->currentEnviroment = 'development' :
 			$this->currentEnviroment = 'production';
-		}
+
 
 		return $this->currentEnviroment;
 	}

--- a/src/HXPHP/System/Configs/Environment.php
+++ b/src/HXPHP/System/Configs/Environment.php
@@ -18,13 +18,13 @@ class Environment
 	{
 		if ($environment == null)
 			$environment = $this->defaultEnvironment;
-		
+
 		$name = strtolower(Tools::filteredName($environment));
 		$object = 'HXPHP\System\Configs\Environments\Environment' . ucfirst(Tools::filteredName($environment));
-		
-		if ( ! class_exists($object)) {
+
+		if ( ! class_exists($object))
 			throw new \Exception('O ambiente informado nao esta definido nas configuracoes do sistema.');
-		}
+
 		else {
 			$this->$name = new $object();
 

--- a/src/HXPHP/System/Configs/LoadModules.php
+++ b/src/HXPHP/System/Configs/LoadModules.php
@@ -21,12 +21,12 @@ class LoadModules
 			$module_class = Tools::filteredName(ucwords($module));
 			$object = 'HXPHP\System\Configs\Modules\\'.$module_class;
 
-			if ( ! class_exists($object)) {
+			if ( ! class_exists($object))
 				throw new \Exception("O modulo <'$object'> informado nao existe.", 1);
-			}
-			else {
+
+			else
 				$obj->$module = new $object();
-			}
+			
 		}
 		return $obj;
 	}

--- a/src/HXPHP/System/Controller.php
+++ b/src/HXPHP/System/Controller.php
@@ -105,9 +105,9 @@ class Controller
 				$ref = new \ReflectionClass($object);
   				$this->view->$name = $ref->newInstanceArgs($params);
 			}
-			else{
+			else
 				$this->view->$name = new $object();
-			}
+
 
 			return $this->view->$name;
 		}
@@ -120,16 +120,14 @@ class Controller
 	 */
 	public function __get($param)
 	{
-		if (isset($this->view->$param)) {
+		if (isset($this->view->$param))
 			return $this->view->$param;
-		}
-		elseif (isset($this->$param)) {
-			return $this->$param;
-		}
-		else {
-			throw new \Exception("Parametro <$param> nao encontrado.", 1);
-		}
 
+		elseif (isset($this->$param))
+			return $this->$param;
+
+		else
+			throw new \Exception("Parametro <$param> nao encontrado.", 1);		
 	}
 
 	/**

--- a/src/HXPHP/System/Helpers/Alert/Render.php
+++ b/src/HXPHP/System/Helpers/Alert/Render.php
@@ -16,9 +16,9 @@ class Render
 
 		$html = '';
 
-		foreach ($messages as $key => $message) {
+		foreach ($messages as $key => $message)
 			$html .= '<li>' . $message . '</li>';
-		}
+
 
 		return $html;
 	}

--- a/src/HXPHP/System/Helpers/Menu/Attrs.php
+++ b/src/HXPHP/System/Helpers/Menu/Attrs.php
@@ -16,9 +16,9 @@ class Attrs
 
 		$html = '';
 
-		foreach ($attrs as $attr => $value) {
+		foreach ($attrs as $attr => $value)
 			$html.= ' ' . $attr . '="' . $value . '" ';
-		}
+
 
 		return $html;
 	}

--- a/src/HXPHP/System/Helpers/Menu/Render.php
+++ b/src/HXPHP/System/Helpers/Menu/Render.php
@@ -157,9 +157,8 @@ class Render
 				$menu_configs['container']
 			]);
 		}
-		else {
+		else
 			$this->html = $menu;
-		}
 
 		return $this->html;
 	}

--- a/src/HXPHP/System/Http/Request.php
+++ b/src/HXPHP/System/Http/Request.php
@@ -97,11 +97,11 @@ class Request
 	{
 		$filters = [];
 
-		foreach ($request as $key => $value) {
-			if ( ! array_key_exists($key, $custom_filters)) {
+		foreach ($request as $key => $value)
+			if ( ! array_key_exists($key, $custom_filters))
 				$filters[$key] = constant('FILTER_SANITIZE_STRING');
-			}
-		}
+
+
 
 		if (is_array($custom_filters) && is_array($custom_filters))
 			$filters = array_merge($filters,$custom_filters);
@@ -118,13 +118,13 @@ class Request
 	{
 		$get = $this->filter($_GET, INPUT_GET, $this->custom_filters);
 
-		if ( ! $name) {
+		if ( ! $name)
 			return $get;
-		}
 
-		if ( ! isset($get[$name])) {
+
+		if ( ! isset($get[$name]))
 			return null;
-		}
+
 
 		return $get[$name];
 	}
@@ -138,13 +138,12 @@ class Request
 	{
 		$post = $this->filter($_POST, INPUT_POST, $this->custom_filters);
 
-		if ( ! $name) {
+		if ( ! $name)
 			return $post;
-		}
 
-		if ( ! isset($post[$name])) {
+		if ( ! isset($post[$name]))
 			return null;
-		}
+
 
 		return $post[$name];
 	}
@@ -176,9 +175,9 @@ class Request
 	{
 		$method = $_SERVER['REQUEST_METHOD'];
 
-		if ($value) {
+		if ($value)
 			return $method == $value;
-		}
+
 
 		return $method;
 	}

--- a/src/HXPHP/System/Services/Auth/Auth.php
+++ b/src/HXPHP/System/Services/Auth/Auth.php
@@ -51,7 +51,7 @@ class Auth
 		$subfolder = empty($subfolder) ? 'default' : $subfolder;
 
 		if (!isset($after_login[$subfolder]) || !isset($after_logout[$subfolder]))
-			throw new \Exception("Verifique as configuracoes de autenticacao para a subpasta: < $subfolder >", 1);	
+			throw new \Exception("Verifique as configuracoes de autenticacao para a subpasta: < $subfolder >", 1);
 
 		//Configuração
 		$this->url_redirect_after_login = $after_login[$subfolder];
@@ -105,13 +105,11 @@ class Auth
 	 */
 	public function redirectCheck($redirect = false)
 	{
-		if ($redirect && $this->login_check()) {
+		if ($redirect && $this->login_check())
 			$this->response->redirectTo($this->url_redirect_after_login);
-		}
-		elseif (!$this->login_check()) {
+		elseif (!$this->login_check())
 			if (!$redirect)
 				$this->logout();
-		}
 	}
 
 	/**
@@ -125,7 +123,7 @@ class Auth
 			 $this->storage->exists($this->subfolder . '_login_string') ) {
 
 			$login_string = hash('sha512', $this->storage->get('username')
-											 . $this->request->server('REMOTE_ADDR') 
+											 . $this->request->server('REMOTE_ADDR')
 											 . $this->request->server('HTTP_USER_AGENT'));
 
 			if ($login_string == $this->storage->get($this->subfolder . '_login_string'))

--- a/src/HXPHP/System/Services/StartSession/StartSession.php
+++ b/src/HXPHP/System/Services/StartSession/StartSession.php
@@ -9,19 +9,19 @@ class StartSession
 	 * @param  boolean $regenerate Regerar sessão após start
 	 * @return void
 	 */
-	static function sec_session_start ($regenerate = false) 
+	static function sec_session_start ($regenerate = false)
 	{
-        ini_set('session.use_only_cookies', 1);
+                ini_set('session.use_only_cookies', 1);
 
-        $cookieParams = session_get_cookie_params();
+                $cookieParams = session_get_cookie_params();
 
-        session_set_cookie_params($cookieParams["lifetime"], $cookieParams["path"], $cookieParams["domain"], false, true); 
+                session_set_cookie_params($cookieParams["lifetime"], $cookieParams["path"], $cookieParams["domain"], false, true);
 
-        session_name('sec_session_id');
-        session_start();
-        
-        if ($regenerate) {
-        	session_regenerate_id(true);
-        }
+                session_name('sec_session_id');
+                session_start();
+
+                if ($regenerate)
+                        session_regenerate_id(true);
+
 	}
 }

--- a/src/HXPHP/System/Storage/Session.php
+++ b/src/HXPHP/System/Storage/Session.php
@@ -28,9 +28,9 @@ class Session implements StorageInterface
 	 */
 	public function get($name)
 	{
-		if ($this->exists($name)) {
+		if ($this->exists($name))
 			return $_SESSION[self::PREFIX][$name];
-		}
+
 
 		return null;
 	}
@@ -51,8 +51,8 @@ class Session implements StorageInterface
 	 */
 	public function clear($name)
 	{
-		if ($this->exists($name)) {
+		if ($this->exists($name)) 
 			unset($_SESSION[self::PREFIX][$name]);
-		}
+
 	}
 }

--- a/src/HXPHP/System/View.php
+++ b/src/HXPHP/System/View.php
@@ -174,13 +174,10 @@ class View
 	 */
 	public function setAssets($type, $assets)
 	{
-		if (is_array($assets)) {
-			$this->assets[$type] = array_merge($this->assets[$type], $assets);
-		}
-		else {
-			array_push($this->assets[$type], $assets);
-		}
-
+		(is_array($assets)) ?
+                    $this->assets[$type] = array_merge($this->assets[$type], $assets) :
+                    array_push($this->assets[$type], $assets);
+		
 		return $this;
 	}
 


### PR DESCRIPTION
Remoção de `{}` que possuem apenas uma linha de comando a seguir de `ifs`, `elses `e `foreach`, e substituindo, sempre que possivel, pelo operador ternário `?`