### PR TITLE
Melhora no processamento de verificações

### DIFF
--- a/src/HXPHP/System/App.php
+++ b/src/HXPHP/System/App.php
@@ -76,21 +76,21 @@ class App
 		 */
 		$controllerFile = $controllersDir . $subfolder . $controller . '.php';
 
-		if ( ! file_exists($controllerFile))
+		if (!file_exists($controllerFile))
 			$controllerFile = $controllersDir . $subfolder . $notFoundController . '.php';
 
 		//Inclusão do Controller
 		require_once($controllerFile);
 
 		//Verifica se a classe correspondente ao Controller existe
-		if ( ! class_exists($controller))
+		if (!class_exists($controller))
 			$controller = $notFoundController;
 
 
 		$app = new $controller($this->configs);
 
 		//Verifica se a Action requisitada não existe
-		if ( ! method_exists($app, $action))
+		if (!method_exists($app, $action))
 			$action = 'indexAction';
 
 		//Injeção das configurações

--- a/src/HXPHP/System/Configs/Config.php
+++ b/src/HXPHP/System/Configs/Config.php
@@ -19,10 +19,10 @@ class Config
 	public function __get($param) {
 		$current = $this->define->getDefault();
 
-		if (isset($this->env->$current->$param))
+		if ($this->env->$current->$param)
 			return $this->env->$current->$param;
 
-		else if(isset($this->global->$param)) 
+		else if($this->global->$param)
 			return $this->global->$param;
 
 

--- a/src/HXPHP/System/Configs/DefineEnvironment.php
+++ b/src/HXPHP/System/Configs/DefineEnvironment.php
@@ -22,7 +22,7 @@ class DefineEnvironment
 	public function setDefaultEnv($environment)
 	{
 		$env = new Environment;
-		if ( is_object($env->add($environment)) )
+		if (is_object($env->add($environment)))
 			$this->currentEnviroment = $environment;
 	}
 

--- a/src/HXPHP/System/Configs/Environment.php
+++ b/src/HXPHP/System/Configs/Environment.php
@@ -16,13 +16,13 @@ class Environment
 
 	public function add($environment = null)
 	{
-		if ($environment == null)
+		if (!$environment)
 			$environment = $this->defaultEnvironment;
 
 		$name = strtolower(Tools::filteredName($environment));
 		$object = 'HXPHP\System\Configs\Environments\Environment' . ucfirst(Tools::filteredName($environment));
 
-		if ( ! class_exists($object))
+		if (!class_exists($object))
 			throw new \Exception('O ambiente informado nao esta definido nas configuracoes do sistema.');
 
 		else {

--- a/src/HXPHP/System/Configs/LoadModules.php
+++ b/src/HXPHP/System/Configs/LoadModules.php
@@ -21,12 +21,12 @@ class LoadModules
 			$module_class = Tools::filteredName(ucwords($module));
 			$object = 'HXPHP\System\Configs\Modules\\'.$module_class;
 
-			if ( ! class_exists($object))
+			if (!class_exists($object))
 				throw new \Exception("O modulo <'$object'> informado nao existe.", 1);
 
 			else
 				$obj->$module = new $object();
-			
+
 		}
 		return $obj;
 	}

--- a/src/HXPHP/System/Configs/Modules/Database.php
+++ b/src/HXPHP/System/Configs/Modules/Database.php
@@ -27,7 +27,7 @@ class Database
 	{
 		foreach ($data as $param => $value) {
 
-			if ( ! property_exists($this, $param))
+			if (!property_exists($this, $param))
 				throw new \Exception("O parametro <$param> nao existe. Verifique a sintaxe e tente novamente", true);
 
 			$this->$param = $value;

--- a/src/HXPHP/System/Controller.php
+++ b/src/HXPHP/System/Controller.php
@@ -35,7 +35,7 @@ class Controller
 		$this->view = new View;
 		$this->response = new Http\Response;
 
-		if (!is_null($configs) && $configs instanceof Configs\Config)
+		if ($configs && $configs instanceof Configs\Config)
 			$this->setConfigs($configs);
 	}
 
@@ -71,7 +71,7 @@ class Controller
 	{
 		$total_args = func_num_args();
 
-		if ($total_args == 0)
+		if (!$total_args)
 			throw new \Exception("Nenhum objeto foi definido para ser carregado.", 1);
 
 
@@ -88,7 +88,7 @@ class Controller
 		 * parâmetros para o construtor do objeto injetado
 		 */
 		unset($args[0]);
-		$params = empty($args) ? [] : array_values($args);
+		$params = !($args) ? [] : array_values($args);
 
 		/**
 		 * Tratamento que adiciona a pasta do módulo
@@ -101,7 +101,7 @@ class Controller
 			$name = end($explode);
 			$name = strtolower(Tools::filteredName($name));
 
-			if ( ! empty($params)) {
+			if ($params) {
 				$ref = new \ReflectionClass($object);
   				$this->view->$name = $ref->newInstanceArgs($params);
 			}
@@ -120,14 +120,14 @@ class Controller
 	 */
 	public function __get($param)
 	{
-		if (isset($this->view->$param))
+		if ($this->view->$param)
 			return $this->view->$param;
 
-		elseif (isset($this->$param))
+		elseif ($this->$param)
 			return $this->$param;
 
 		else
-			throw new \Exception("Parametro <$param> nao encontrado.", 1);		
+			throw new \Exception("Parametro <$param> nao encontrado.", 1);
 	}
 
 	/**

--- a/src/HXPHP/System/Helpers/Alert/Alert.php
+++ b/src/HXPHP/System/Helpers/Alert/Alert.php
@@ -6,7 +6,7 @@ use HXPHP\System\Storage as Storage;
 
 class Alert
 {
-	
+
 	/**
 	 * Injeção do controle de sessão
 	 * @var object
@@ -25,10 +25,10 @@ class Alert
 		//Injeção da Sessão
 		$this->storage = new Storage\Session;
 
-		if (count($alert) == 1)
+		if (count($alert))
 			return null;
 
-		$alert[2] = ! isset($alert[2]) ? '' : $alert[2];
+		$alert[2] = !($alert[2]) ? '' : $alert[2];
 
 		list($style, $title, $message) = $alert;
 
@@ -64,7 +64,7 @@ class Alert
 		$message = $this->storage->get('message');
 		$this->storage->clear('message');
 
-		return $message; 
+		return $message;
 	}
 
 	/**

--- a/src/HXPHP/System/Helpers/Alert/Template.php
+++ b/src/HXPHP/System/Helpers/Alert/Template.php
@@ -33,12 +33,12 @@ class Template
 	 */
 	public function get($list = false)
 	{
-		if ($list === true)
+		if ($list)
 			$this->setTemplateFile('alert-list');
 
 		$template = $this->template_path . $this->template_file . '.html';
 
-		if ( ! file_exists($template))
+		if (!file_exists($template))
 			throw new \Exception("O template para a mensagem nao foi localizado: $template", 1);
 
 		return file_get_contents($template);

--- a/src/HXPHP/System/Helpers/Menu/Attrs.php
+++ b/src/HXPHP/System/Helpers/Menu/Attrs.php
@@ -11,7 +11,7 @@ class Attrs
 	 */
 	public static function render($attrs)
 	{
-		if (empty($attrs) || !is_array($attrs))
+		if (!$attrs || !is_array($attrs))
 			return null;
 
 		$html = '';

--- a/src/HXPHP/System/Helpers/Menu/CheckActive.php
+++ b/src/HXPHP/System/Helpers/Menu/CheckActive.php
@@ -30,7 +30,7 @@ class CheckActive
 	public function link($URL)
 	{
 		$position = strpos($this->current_URL, $URL);
-		return $this->current_URL === $URL || ($position !== false && $position > 0) ? true : false;
+		return $this->current_URL === $URL || ($position && $position > 0) ? true : false;
 	}
 
 	/**
@@ -46,7 +46,7 @@ class CheckActive
 		foreach ($values as $dropdown_link) {
 			$real_link = $this->realLink->get($dropdown_link);
 
-			if ($this->link($real_link) === true) {
+			if ($this->link($real_link)) {
 				$status = true;
 				break;
 			}

--- a/src/HXPHP/System/Helpers/Menu/Elements.php
+++ b/src/HXPHP/System/Helpers/Menu/Elements.php
@@ -91,10 +91,10 @@ class Elements
 	 */
 	public static function get($name, array $args = [])
 	{
-		if ( ! isset(self::$elements[$name]))
+		if (!self::$elements[$name])
 			return false;
 
-		if ( ! empty($args)) {
+		if ($args) {
 			$args = array_values($args);
 			array_unshift($args, self::$elements[$name]);
 

--- a/src/HXPHP/System/Helpers/Menu/MenuData.php
+++ b/src/HXPHP/System/Helpers/Menu/MenuData.php
@@ -16,7 +16,7 @@ class MenuData
 		$explode = explode('/', $key);
 
 		$obj->title = $explode[0];
-		$obj->icon = isset($explode[1]) ? $explode[1] : '';
+		$obj->icon = ($explode[1]) ? $explode[1] : '';
 
 		return $obj;
 	}

--- a/src/HXPHP/System/Helpers/Menu/Render.php
+++ b/src/HXPHP/System/Helpers/Menu/Render.php
@@ -43,10 +43,10 @@ class Render
 	 */
 	public function getHTML($role = 'default')
 	{
-		$menu_itens = isset($this->menu_itens[$role]) ? $this->menu_itens[$role] : [];
+		$menu_itens = ($this->menu_itens[$role]) ? $this->menu_itens[$role] : [];
 		$menu_configs = $this->menu_configs;
 
-		if (empty($menu_itens) || !is_array($menu_itens))
+		if (!($menu_itens) || !is_array($menu_itens))
 			return 'Nenhum menu foi definido para o seguinte nivel de acesso: <strong>' . $role . '</strong>';
 
 		$itens = '';
@@ -59,14 +59,14 @@ class Render
 			$real_link = $this->realLink->get($value);
 
 			// Dropdown
-			if (is_array($value) && !empty($value)) {
+			if (is_array($value) && ($value)) {
 				$dropdown_itens = '';
 
 				foreach ($value as $dropdown_key => $dropdown_value) {
 					$submenu_data = MenuData::get($dropdown_key);
 					$submenu_real_link = $this->realLink->get($dropdown_value);
 
-					$submenu_link_active = $this->checkActive->link($submenu_real_link) === true ? $menu_configs['link_active_class'] : '';
+					$submenu_link_active = ($this->checkActive->link($submenu_real_link)) ? $menu_configs['link_active_class'] : '';
 
 					$link = Elements::get('link', [
 						$submenu_real_link,
@@ -79,7 +79,7 @@ class Render
 						$menu_configs['link_after']
 					]);
 
-					$submenu_active = $this->checkActive->link($submenu_real_link) === true ? $menu_configs['dropdown_item_active_class'] : '';
+					$submenu_active = ($this->checkActive->link($submenu_real_link)) ? $menu_configs['dropdown_item_active_class'] : '';
 
 					$dropdown_itens.= Elements::get('dropdown_item', [
 						$menu_configs['dropdown_item_class'],
@@ -95,7 +95,7 @@ class Render
 				]);
 
 				$attrs = Attrs::render($menu_configs['link_dropdown_attrs']);
-				$active = $this->checkActive->dropdown($value) === true ? $menu_configs['link_active_class'] : '';
+				$active = ($this->checkActive->dropdown($value)) ? $menu_configs['link_active_class'] : '';
 
 				$link = Elements::get('link_with_dropdown', [
 					$i,
@@ -110,7 +110,7 @@ class Render
 					$dropdown
 				]);
 
-				$active = $this->checkActive->dropdown($value) === true ? $menu_configs['menu_item_active_class'] : '';
+				$active = ($this->checkActive->dropdown($value)) ? $menu_configs['menu_item_active_class'] : '';
 
 				$itens.= Elements::get('menu_item', [
 					$menu_configs['menu_item_dropdown_class'],
@@ -119,7 +119,7 @@ class Render
 				]);
 			}
 			else {
-				$link_active = $this->checkActive->link($real_link) === true ? $menu_configs['link_active_class'] : '';
+				$link_active = ($this->checkActive->link($real_link)) ? $menu_configs['link_active_class'] : '';
 
 				$link = Elements::get('link', [
 					$real_link,
@@ -132,7 +132,7 @@ class Render
 					$menu_configs['link_after']
 				]);
 
-				$active = $this->checkActive->link($real_link) === true ? $menu_configs['menu_item_active_class'] : '';
+				$active = ($this->checkActive->link($real_link)) ? $menu_configs['menu_item_active_class'] : '';
 
 				$itens.= Elements::get('menu_item', [
 					$menu_configs['menu_item_class'],
@@ -148,7 +148,7 @@ class Render
 			$itens
 		]);
 
-		if ($menu_configs['container'] !== false) {
+		if ($menu_configs['container']) {
 			$this->html = Elements::get('container', [
 				$menu_configs['container'],
 				$menu_configs['container_id'],

--- a/src/HXPHP/System/Http/Request.php
+++ b/src/HXPHP/System/Http/Request.php
@@ -37,31 +37,31 @@ class Request
 	 */
 	public function initialize($baseURI, $controller_directory)
 	{
-		if ( ! empty($baseURI) && ! empty($controller_directory)) {
+		if ($baseURI && $controller_directory) {
 			$explode = array_values(array_filter(explode('/', $_SERVER['REQUEST_URI'])));
 
-			if (isset($explode[0]) && $explode[0] == str_replace('/', '', $baseURI)) {
+			if (($explode[0]) && $explode[0] == str_replace('/', '', $baseURI)) {
 				unset($explode[0]);
 				$explode = array_values($explode);
 			}
 
-			if (count($explode) == 0)
+			if (!count($explode))
 				return $this;
 
 
 			if (file_exists($controller_directory . $explode[0])) {
 				$this->subfolder = $explode[0] . DS;
 
-				if (isset($explode[1]))
+				if (($explode[1]))
 					$this->controller = Tools::filteredName($explode[1]).'Controller';
 
-				if (isset($explode[2])) {
+				if ($explode[2]) {
 					$this->action = lcfirst(Tools::filteredName($explode[2])).'Action';
 
 					unset($explode[2]);
 				}
 			}
-			elseif (count($explode) == 1) {
+			elseif (count($explode)) {
 				$this->controller = Tools::filteredName($explode[0]).'Controller';
 
 				return $this;
@@ -98,7 +98,7 @@ class Request
 		$filters = [];
 
 		foreach ($request as $key => $value)
-			if ( ! array_key_exists($key, $custom_filters))
+			if (!array_key_exists($key, $custom_filters))
 				$filters[$key] = constant('FILTER_SANITIZE_STRING');
 
 
@@ -118,11 +118,11 @@ class Request
 	{
 		$get = $this->filter($_GET, INPUT_GET, $this->custom_filters);
 
-		if ( ! $name)
+		if (!$name)
 			return $get;
 
 
-		if ( ! isset($get[$name]))
+		if (!($get[$name]))
 			return null;
 
 
@@ -138,10 +138,10 @@ class Request
 	{
 		$post = $this->filter($_POST, INPUT_POST, $this->custom_filters);
 
-		if ( ! $name)
+		if (!$name)
 			return $post;
 
-		if ( ! isset($post[$name]))
+		if (!($post[$name]))
 			return null;
 
 
@@ -160,7 +160,7 @@ class Request
         if(!$name)
             return $server;
 
-        if(!isset($server[$name]))
+        if(!($server[$name]))
             return NULL;
 
         return $server[$name];

--- a/src/HXPHP/System/Modules/Messages/LoadTemplate.php
+++ b/src/HXPHP/System/Modules/Messages/LoadTemplate.php
@@ -28,7 +28,7 @@ class LoadTemplate
 		 */
 		$template = dirname(__FILE__) . DS . 'templates' . DS . $template . '.json';
 
-		if ( ! file_exists($template))
+		if (!file_exists($template))
 			throw new \Exception("O template nao foi localizado: <'$template'>", 1);
 
 		$this->file  = $template;

--- a/src/HXPHP/System/Modules/Messages/Messages.php
+++ b/src/HXPHP/System/Modules/Messages/Messages.php
@@ -39,7 +39,7 @@ class Messages
 		 * JSON => ARRAY
 		 * @var array
 		 */
-		if($template->getJson() !== false)
+		if($template->getJson())
 			$this->content = json_decode($template->getJson(), true);
 
 		return $this;
@@ -65,7 +65,7 @@ class Messages
 	{
 		$block = $this->block;
 
-		if ( ! is_null($block))
+		if ($block)
 			return call_user_func_array([&$this->$block, $method], $args);
 
 		throw new \Exception("O metodo <$method> nao existe.", 1);
@@ -78,7 +78,7 @@ class Messages
 	 */
 	public function __get($block)
 	{
-		if(isset($this->content[$block])) {
+		if($this->content[$block]) {
 			$this->$block = new Template($this->content[$block]);
 
 			return $this->$block;

--- a/src/HXPHP/System/Modules/Messages/Template.php
+++ b/src/HXPHP/System/Modules/Messages/Template.php
@@ -23,12 +23,12 @@ class Template
 	 */
 	public function getByCode($code, array $fields = [])
 	{
-		if (isset($this->content[$code])){
+		if ($this->content[$code]){
 			$output = $this->content[$code];
 
-			if ( ! empty($fields) ) {
+			if ($fields) {
 				foreach ($fields as $field => $params) {
-					if ( ! isset($output[$field]) || empty($params))
+					if (!($output[$field]) || !($params))
 						continue;
 
 					$output[$field] = vsprintf($output[$field], $params);

--- a/src/HXPHP/System/Services/Auth/Auth.php
+++ b/src/HXPHP/System/Services/Auth/Auth.php
@@ -50,7 +50,7 @@ class Auth
 		$subfolder = str_replace('/', '', $subfolder);
 		$subfolder = empty($subfolder) ? 'default' : $subfolder;
 
-		if (!isset($after_login[$subfolder]) || !isset($after_logout[$subfolder]))
+		if (!($after_login[$subfolder]) || !($after_logout[$subfolder]))
 			throw new \Exception("Verifique as configuracoes de autenticacao para a subpasta: < $subfolder >", 1);
 
 		//Configuração
@@ -78,7 +78,7 @@ class Auth
 		$this->storage->set('username', $username);
 		$this->storage->set($this->subfolder . '_login_string', $login_string);
 
-		if ($this->redirect === true)
+		if ($this->redirect)
 			return $this->response->redirectTo($this->url_redirect_after_login);
 	}
 
@@ -95,7 +95,7 @@ class Auth
 		setcookie(session_name(), '', time() - 42000, $params["path"], $params["domain"], $params["secure"], $params["httponly"]);
 		session_destroy();
 
-		if ($this->redirect === true)
+		if ($this->redirect)
 			return $this->response->redirectTo($this->url_redirect_after_logout);
 	}
 

--- a/src/HXPHP/System/Services/Email/Email.php
+++ b/src/HXPHP/System/Services/Email/Email.php
@@ -33,10 +33,10 @@ class Email
 		$to = strtolower($to);
 		$subject = addslashes(trim($subject));
 
-		$message = $accept_html === false ? strip_tags($message) : $message;
+		$message = !($accept_html) ? strip_tags($message) : $message;
 		$message = nl2br($message);
 
-		$from = !is_null($this->from) && empty($from) ? $this->from : $from;
+		$from = ($this->from) && !($from) ? $this->from : $from;
 
 		ksort($from);
 		$from = array_values($from);

--- a/src/HXPHP/System/Storage/Session.php
+++ b/src/HXPHP/System/Storage/Session.php
@@ -31,7 +31,6 @@ class Session implements StorageInterface
 		if ($this->exists($name))
 			return $_SESSION[self::PREFIX][$name];
 
-
 		return null;
 	}
 
@@ -51,8 +50,7 @@ class Session implements StorageInterface
 	 */
 	public function clear($name)
 	{
-		if ($this->exists($name)) 
+		if ($this->exists($name))
 			unset($_SESSION[self::PREFIX][$name]);
-
 	}
 }

--- a/src/HXPHP/System/Tools.php
+++ b/src/HXPHP/System/Tools.php
@@ -12,10 +12,7 @@ class Tools
 	{
 		echo '<pre>';
 
-		if ($dump)
-			var_dump($data);
-		else
-			print_r($data);
+		($dump) ? var_dump($data) : print_r($data);
 
 		echo '</pre>';
 	}
@@ -29,7 +26,7 @@ class Tools
 	static function hashHX($password, $salt = null)
 	{
 
-		if (is_null($salt))
+		if (!$salt)
 			$salt = hash('sha512', uniqid(mt_rand(1, mt_getrandmax()), true));
 
 		$password = hash('sha512', $password.$salt);

--- a/src/HXPHP/System/View.php
+++ b/src/HXPHP/System/View.php
@@ -69,7 +69,7 @@ class View
 		];
 
 		foreach ($default_values as $setting => $value) {
-			if(is_null($this->$setting)) {
+			if(!$this->$setting) {
 				$view_settings->$setting = $value;
 				continue;
 			}
@@ -177,7 +177,7 @@ class View
 		(is_array($assets)) ?
                     $this->assets[$type] = array_merge($this->assets[$type], $assets) :
                     array_push($this->assets[$type], $assets);
-		
+
 		return $this;
 	}
 
@@ -202,7 +202,7 @@ class View
 				break;
 		}
 
-		if (count($custom_assets) > 0)
+		if (count($custom_assets))
 			foreach ($custom_assets as $file)
 				$add_assets .= sprintf($tag,$file);
 
@@ -246,11 +246,11 @@ class View
 		//Verifica a existência da VIEW
 		$view = $viewsDir . $this->path . DS . $this->file . $viewsExt;
 
-		if ( ! file_exists($view))
+		if (!file_exists($view))
 			throw new \Exception("Erro fatal: A view <'$view'> não foi encontrada. Por favor, crie a view e tente novamente.", 1);
 
 		//Mecanismo de template
-		if ($this->template === false) {
+		if (!$this->template) {
 			//Inclusão da view
 			require_once($view);
 			exit();
@@ -260,7 +260,7 @@ class View
 		$header = $viewsDir . $this->header . $viewsExt;
 		$footer = $viewsDir . $this->footer . $viewsExt;
 
-		if ( ! file_exists($header) || ! file_exists($footer))
+		if (!file_exists($header) || !file_exists($footer))
 			throw new \Exception("Erro fatal: O header <$header> ou o footer <$footer> não existe. Por favor, verifique e tente novamente.");
 
 		//Inclusão dos arquivos


### PR DESCRIPTION
PR contendo melhoras de verificações. Segundo alguns pesquisadores, a utilização apenas de `if`, ao invés de `isset()`, `is_null()`, etc., melhora o desempenho das verificações, logo, do tempo de processamento. Foi usado a [tabela de tipo de verificações](http://php.net/manual/en/types.comparisons.php)