### PR TITLE
Implantação do método roleCheck()

### DIFF
--- a/src/HXPHP/System/Services/Auth/Auth.php
+++ b/src/HXPHP/System/Services/Auth/Auth.php
@@ -67,8 +67,9 @@ class Auth
 	 * Autentica o usuário
 	 * @param  integer $user_id  ID do usuário
 	 * @param  string $username  Nome de usuário
+         * @param string $user_role Role do usuário
 	 */
-	public function login($user_id, $username)
+	public function login($user_id, $username, $user_role = null)
 	{
 		$user_id = intval(preg_replace("/[^0-9]+/", "", $user_id));
 		$username = preg_replace("/[^a-zA-Z0-9_\-]+/", "", $username);
@@ -76,6 +77,7 @@ class Auth
 
 		$this->storage->set('user_id', $user_id);
 		$this->storage->set('username', $username);
+                $this->storage->set('user_role', $user_role);
 		$this->storage->set($this->subfolder . '_login_string', $login_string);
 
 		if ($this->redirect)
@@ -112,6 +114,21 @@ class Auth
 				$this->logout();
 	}
 
+        /**
+         * Valida a autenticação e redireciona mediante o estado do usuário
+         * @param array $roles Array com roles são permitidas o acesso a esta página
+         */
+        public function roleCheck($roles = [])
+        {
+            if($this->loginCheck())
+            {
+                if(!in_array($this->getUserRole(), $roles))
+                    $this->redirectCheck(true);
+            }
+            else
+                $this->response->redirectTo($this->url_redirect_after_logout);
+        }
+
 	/**
 	 * Verifica se o usuário está logado
 	 * @return boolean Status da autenticação
@@ -141,4 +158,13 @@ class Auth
 	{
 		return $this->storage->get('user_id');
 	}
+
+        /**
+         * Retorna o role do usuário autenticado
+         * @return string Role do usuário
+         */
+        public function getUserRole()
+        {
+            return $this->storage->get('user_role');
+        }
 }

--- a/src/HXPHP/System/Storage/Cookie.php
+++ b/src/HXPHP/System/Storage/Cookie.php
@@ -15,7 +15,11 @@ class Cookie implements StorageInterface
     {
         $cookieParams = session_get_cookie_params();
 
-        setcookie($name, $value, time() + $time, $cookieParams['path'], $cookieParams['domain'] ,false, true);
+        if(is_array($name))
+            foreach ($name as $cookie => $value)
+                setcookie($cookie, $value, time() + $time, $cookieParams['path'], $cookieParams['domain'] ,false, true);
+        else
+            setcookie($name, $value, time() + $time, $cookieParams['path'], $cookieParams['domain'] ,false, true);
 
         return $this;
     }

--- a/src/HXPHP/System/Storage/Session.php
+++ b/src/HXPHP/System/Storage/Session.php
@@ -16,9 +16,14 @@ class Session implements StorageInterface
 	 */
 	public function set($name, $value)
 	{
-		$_SESSION[self::PREFIX][$name] = $value;
+                if(is_array($name))
+                    foreach ($name as $session => $value)
+                        $_SESSION[self::PREFIX][$session] = $value;
 
-		return $this;
+                else
+                    $_SESSION[self::PREFIX][$name] = $value;
+
+                return $this;
 	}
 
 	/**
@@ -50,7 +55,17 @@ class Session implements StorageInterface
 	 */
 	public function clear($name)
 	{
-		if ($this->exists($name))
-			unset($_SESSION[self::PREFIX][$name]);
+                if(is_array($name))
+                {
+                    foreach ($name as $session)
+                    {
+                        if ($this->exists($session))
+                            unset($_SESSION[self::PREFIX][$session]);
+                    }
+                }
+
+                else
+                    if ($this->exists($name))
+                        unset($_SESSION[self::PREFIX][$name]);
 	}
 }


### PR DESCRIPTION
Implantação de um antigo método presente no HXPHP chamado roleCheck(), que permite a verificação de níveis de usuário ao acessarem partes do sistema.