### PR TITLE
Possibilidade de rodar uma aplicação baseada em HXPHP a partir de qualquer diretório

### DIFF
--- a/src/HXPHP/System/Http/Request.php
+++ b/src/HXPHP/System/Http/Request.php
@@ -40,13 +40,20 @@ class Request
 		if ( ! empty($baseURI) && ! empty($controller_directory)) {
 			$explode = array_values(array_filter(explode('/', $_SERVER['REQUEST_URI'])));
 
-			if (isset($explode[0]) && $explode[0] == str_replace('/', '', $baseURI)) {
-				unset($explode[0]);
-				$explode = array_values($explode);
-			}
+			$baseURICount = count(array_filter(explode('/', $baseURI)));
 
-			if (count($explode) == 0)
+			if (count($explode) == $baseURICount)
 				return $this;
+
+			if (count($explode) != $baseURICount){
+
+				for($i=0; $i < $baseURICount; $i++) { 
+					unset($explode[$i]);
+				}
+
+				$explode = array_values($explode);
+
+			}
 			
 			if (file_exists($controller_directory . $explode[0])) {
 				$this->subfolder = $explode[0] . DS;


### PR DESCRIPTION
Notei que ao tentar utilizar o framework em aplicações que estavam dentro de mais de um diretório não haveria suporte.

Corrigi para suportar qualquer nível de diretório, testei ações e parâmetros, comportamentos padrões.

**Antes:**
/www/sistema/ - Suportava
/www/setor/aplicacoes/sistema/ - Não suportava

**Agora:**
/www/sistema/ - Suporta
/www/setor/aplicacoes/sistema/ - Suporta
/www/w/x/y/z/sistema/ - Suporta