### PR TITLE
Melhoria display_errors do PHP

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,7 +1,8 @@
 <?php
 	ob_start();
 
-	set_time_limit(0);
+	ini_set('display_errors', 1);
+        set_time_limit(0);
 
 	date_default_timezone_set('America/Sao_Paulo');
 	setlocale(LC_ALL, 'pt_BR', 'pt_BR.utf-8', 'pt_BR.utf-8', 'portuguese');

--- a/index.php
+++ b/index.php
@@ -1,7 +1,6 @@
 <?php
 	ob_start();
 
-	ini_set('display_errors', 1);
 	set_time_limit(0);
 
 	date_default_timezone_set('America/Sao_Paulo');

--- a/src/HXPHP/System/Configs/Environments/EnvironmentDevelopment.php
+++ b/src/HXPHP/System/Configs/Environments/EnvironmentDevelopment.php
@@ -10,6 +10,8 @@ class EnvironmentDevelopment extends Configs\AbstractEnvironment
 
 	public function __construct()
 	{
+                ini_set('display_errors', 1);
+
 		parent::__construct();
 		$this->servers = [
 			'localhost',

--- a/src/HXPHP/System/Configs/Environments/EnvironmentProduction.php
+++ b/src/HXPHP/System/Configs/Environments/EnvironmentProduction.php
@@ -6,5 +6,8 @@ use HXPHP\System\Configs as Configs;
 
 class EnvironmentProduction extends Configs\AbstractEnvironment
 {
-	
+        public function __construct()
+        {
+            ini_set('display_errors', 0);
+        }
 }

--- a/src/HXPHP/System/Configs/Environments/EnvironmentTests.php
+++ b/src/HXPHP/System/Configs/Environments/EnvironmentTests.php
@@ -6,5 +6,8 @@ use HXPHP\System\Configs as Configs;
 
 class EnvironmentTests extends Configs\AbstractEnvironment
 {
-	
+	public function __construct()
+        {
+            ini_set('display_errors', 1);
+        }
 }


### PR DESCRIPTION
Visando uma melhor experiência ao usuário, não mostrar os erros gerados pelo PHP é uma saída, porém, as vezes, nós, desenvolvedores, esquecemos de alterar a propriedade `display_errors`.

Esse PR visa melhorar isto, definindo está propriedade de acordo com o **ambiente**.