### PR TITLE
Acréscimo de tempo de expiração para as sessões

### DIFF
--- a/src/HXPHP/System/Storage/Session/Session.php
+++ b/src/HXPHP/System/Storage/Session/Session.php
@@ -13,11 +13,17 @@ class Session implements \HXPHP\System\Storage\StorageInterface
 	 * Método que cria uma sessão
 	 * @param string $name  Nome da sessão
 	 * @param string $value Conteúdo da sessão
+     * @param int $timeout  Tempo de expiração da sessão
 	 */
-	public function set($name, $value)
+	public function set($name, $value, $timeout = null)
 	{
 		$_SESSION[self::PREFIX][$name] = $value;
-
+        
+        if ($timeout && is_int($timeout)) {
+            $_SESSION[self::PREFIX][$name.'_created_at'] = time();
+            $_SESSION[self::PREFIX][$name.'_timeout'] = $timeout;
+        }
+        
 		return $this;
 	}
 
@@ -28,8 +34,12 @@ class Session implements \HXPHP\System\Storage\StorageInterface
 	 */
 	public function get($name)
 	{
-		if ($this->exists($name))
-			return $_SESSION[self::PREFIX][$name];
+		if ($this->exists($name)) {            
+            if (!$this->hasExpired($name))
+                return $_SESSION[self::PREFIX][$name];
+            else
+                return false;
+        }
 
 		return null;
 	}
@@ -43,6 +53,36 @@ class Session implements \HXPHP\System\Storage\StorageInterface
 	{
 		return isset($_SESSION[self::PREFIX][$name]);
 	}
+    
+    /**
+    * Verifica se uma sessão já expirou
+    * @param string $name   Nome da sessão
+    * @return boolean       Sessão expirada ou não
+    */
+    public function hasExpired($name)
+    {
+        if (!$this->exists($name.'_timeout'))
+            return false;
+        
+        if (!$this->exists($name.'_created_at'))
+            throw new \LogicException('A sessão < '.$name.'_created_at > não existe.');
+        
+        if ($this->get($name.'_created_at') + $this->get($name.'_timeout') < time())
+            return true;
+    }
+    
+    /**
+    * Quantidade de tempo restante para o timeout de uma sessão
+    * @param string $name   Nome da sessão
+    * @return date          Quantidade de tempo restante para o timeout
+    */
+    public function getTimeLeftOf($name)
+    {
+        if ($this->hasExpired($name))
+            return 0;
+        
+        return ($this->get($name.'_created_at') + $this->get($name.'_timeout')) - time();
+    }
 
 	/**
 	 * Exclui uma sessão


### PR DESCRIPTION
Criei sistema de tempo de expiração para as sessões.
Assim, é possível criar sessões com timeout.

Utilização:

## Criando sessão com timeout:
```php
$this->session->set('NomeDaSessao', '100');
```

****O tempo é sempre medido em segundos.** 
No exemplo acima, a sessão seria válida por até 100 segundos.

Para setar uma sessão em minutos:
```php
$this->session->set('NomeDaSessao', '15 * 60');
```

A sessão acima possui um tempo de expiração de 15 minutos.

Para criar sessões sem timeout, basta não setar o segundo argumento:

```php
$this->session->set('NomeDaSessao'); //Não possui tempo de expiração
```

## Get de sessão expirada

Tentar capturar uma sessão expirada irá retornar um `false`;

Exemplo:

```php
$this->session->get('NomeDaSessaoExpirada'); //FALSE
```

## Verificar se sessão já expirou

É possível verificar se uma sessão já expirou:

```php
$this->session->hasExpired('NomeDaSessao');
```

Exemplo:
```php
if ($this->session->hasExpired('User'))
    echo 'Desculpe, sua sessão expirou...';
```

## Capturar a quantidade de tempo restante de validade de uma sessão

É possível verificar quanto tempo uma sessão tem antes que expire:

```php
$this->session->getTimeLeftOf('NomeDaSessao');
```

Exemplo:

```php
echo 'Você possui: '.$this->session->getTimeLeftOf('User').' segundos';
```