### PR TITLE
Criação da trait CurrentEnviroment

### DIFF
--- a/src/HXPHP/System/Configs/DefineEnvironment.php
+++ b/src/HXPHP/System/Configs/DefineEnvironment.php
@@ -31,3 +31,12 @@ class DefineEnvironment
 		return $this->currentEnviroment;
 	}
 }
+
+trait CurrentEnviroment
+{
+    public function getCurrentEnvironment()
+    {
+        $default = new DefineEnvironment;
+        return $default->getDefault();
+    }
+}


### PR DESCRIPTION
Muitas vezes, me vi na necessidade de saber em qual ambiente estou desenvolvendo, e encontrei uma solução rápida e eficaz para esse problema.

Criei uma [trait](http://php.net/manual/pt_BR/language.oop5.traits.php), assim posso chama-la na classe Controller, View, Model, etc.

E seu uso é extremamente simples:

- Faço uso dela na classe desejada. Ex: `class Controller { use Configs\CurrentEnviroment; ...`
- Faço uso do método `getCurrentEnvironment()` na action, view, ou model desejado. Ex: `indexAction() { $this->view->setVar('ambiente_atual', $this->getCurrentEnvironment())...`