### PR TITLE
Update view.php métodos flush() e assets()

### DIFF
--- a/src/HXPHP/System/Controller.php
+++ b/src/HXPHP/System/Controller.php
@@ -29,7 +29,7 @@ class Controller
      */
     public $view;
 
-    public function __construct($configs = null)
+    public function __construct(Configs\Config $configs = null)
     {
         //Injeção da VIEW
         $this->view = new View;
@@ -112,7 +112,7 @@ class Controller
      * @param  string $param Atributo
      * @return mixed         Conteúdo do atributo ou Exception
      */
-    public function __get($param)
+    public function __get(string $param)
     {
         if (isset($this->view->$param))
             return $this->view->$param;
@@ -129,7 +129,7 @@ class Controller
      * @param  boolean $controller Define se o controller também será retornado
      * @return string              Link relativo
      */
-    public function getRelativeURL($URL, $controller = true)
+    public function getRelativeURL(string $URL, bool $controller = true)
     {
         $path = $controller === true ? $this->view->path . DS : $this->view->subfolder;
 
@@ -142,7 +142,7 @@ class Controller
      * @param  boolean $external Define se o redirecionamento será relativo ou absoluto
      * @param  boolean $controller Define se o controller também será retornado
      */
-    public function redirectTo($URL, $external = true, $controller = true)
+    public function redirectTo(string $URL, bool $external = true, bool $controller = true)
     {
         $URL = $external === false ? $this->getRelativeURL($URL, $controller) : $URL;
         return $this->response->redirectTo($URL);

--- a/src/HXPHP/System/Model.php
+++ b/src/HXPHP/System/Model.php
@@ -10,7 +10,7 @@ class Model extends \ActiveRecord\Model
      * @param boolean $instantiating_via_find Atributo obrigatório do PHP ActiveRecord
      * @param boolean $new_record             Atributo obrigatório do PHP ActiveRecord
      */
-    public function __construct($attributes = [], $guard_attributes = TRUE, $instantiating_via_find = FALSE, $new_record = TRUE)
+    public function __construct(array $attributes = [], bool $guard_attributes = true, bool $instantiating_via_find = false, bool $new_record = true)
     {
         parent::__construct($attributes, $guard_attributes, $instantiating_via_find, $new_record);
 

--- a/src/HXPHP/System/Tools.php
+++ b/src/HXPHP/System/Tools.php
@@ -7,7 +7,7 @@ class Tools
      * Exibe os dados
      * @param  mist $data Variável que será "debugada"
      */
-    public static function dd($data, $dump = false)
+    public static function dd($data, bool $dump = false)
     {
         echo '<pre>';
 
@@ -16,7 +16,7 @@ class Tools
         echo '</pre>';
     }
 
-    public static function getTemplatePath($component, $name, $templateFile)
+    public static function getTemplatePath(string $component, string $name, string $templateFile)
     {
         $templatePath = TEMPLATES_PATH . $component . DS . $name . DS . $templateFile;
 
@@ -32,7 +32,7 @@ class Tools
      * @param  string $salt     Código alfanumérico
      * @return array            Array com o SALT e a SENHA
      */
-    public static function hashHX($password, $salt = null)
+    public static function hashHX(string $password, string $salt = null)
     {
 
         if (!$salt)
@@ -51,7 +51,7 @@ class Tools
      * @param string $input     String que será convertida
      * @return string           String convertida
      */
-    public static function filteredName($input)
+    public static function filteredName(string $input)
     {
         $input = explode('?', $input);
         $input = $input[0];
@@ -67,7 +67,7 @@ class Tools
         return str_replace(' ', '', ucwords(str_replace($find, $replace, $input)));
     }
 
-    public static function filteredFileName($input)
+    public static function filteredFileName(string $input)
     {
         $input = trim($input);
 
@@ -185,7 +185,7 @@ class Tools
         return strtolower(str_replace(' ', '_', str_replace($find, $replace, $new)));
     }
 
-    public static function decamelize($cameled, $sep = '-')
+    public static function decamelize(string $cameled, string $sep = '-')
     {
         return implode(
                 $sep, array_map(

--- a/src/HXPHP/System/View.php
+++ b/src/HXPHP/System/View.php
@@ -38,7 +38,7 @@ class View
         'js' => []
     ];
 
-    public function setConfigs(Configs\Config $configs, $subfolder, $controller, $action)
+    public function setConfigs(Configs\Config $configs, string $subfolder, string $controller, string $action)
     {
         /**
          * Injeção das Configurações
@@ -97,7 +97,7 @@ class View
      * Define o diretório das views parciais
      * @param string  $partialsDir  Diretório
      */
-    public function setPartialsDir($partialsDir, $overwrite = false)
+    public function setPartialsDir(string $partialsDir, bool $overwrite = false)
     {
         $viewsDir = $this->configs->views->directory;
 
@@ -111,7 +111,7 @@ class View
      * Define o título da página
      * @param string  $title  Título da página
      */
-    public function setTitle($title)
+    public function setTitle(string $title)
     {
         $this->title = $title;
         return $this;
@@ -121,7 +121,7 @@ class View
      * Define a pasta da view
      * @param string  $path  Caminho da View
      */
-    public function setPath($path, $overwrite = false)
+    public function setPath(string $path, $overwrite = false)
     {
         $this->path = $overwrite === false ? $this->subfolder . $path : $path;
         return $this;
@@ -131,7 +131,7 @@ class View
      * Define se o arquivo é miolo (Inclusão de Cabeçalho e Rodapé) ou único
      * @param bool  $template  Template ON/OFF
      */
-    public function setTemplate($template)
+    public function setTemplate(string $template)
     {
         $this->template = $template;
         return $this;
@@ -141,7 +141,7 @@ class View
      * Define o cabeçalho da view
      * @param string  $header  Cabeçalho da View
      */
-    public function setHeader($header, $overwrite = false)
+    public function setHeader(string $header, $overwrite = false)
     {
         $this->header = $overwrite === false ? $this->subfolder . $header : $header;
         return $this;
@@ -151,7 +151,7 @@ class View
      * Define o arquivo da view
      * @param string  $file  Arquivo da View
      */
-    public function setFile($file)
+    public function setFile(string $file)
     {
         $this->file = $file;
         return $this;
@@ -161,7 +161,7 @@ class View
      * Define o rodapé da view
      * @param string  $footer  Rodapé da View
      */
-    public function setFooter($footer, $overwrite = false)
+    public function setFooter(string $footer, $overwrite = false)
     {
         $this->footer = $overwrite === false ? $this->subfolder . $footer : $footer;
         return $this;
@@ -182,7 +182,7 @@ class View
      * @param string  $name  Nome do índice
      * @param string  $value  Valor
      */
-    public function setVar($name, $value)
+    public function setVar(string $name, $value)
     {
         $this->vars[$name] = $value;
         return $this;
@@ -193,7 +193,7 @@ class View
      * @param string  $type  Tipo do arquivo
      * @param string|array  $assets  Arquivo Único | Array com os arquivos
      */
-    public function setAssets($type, $assets)
+    public function setAssets(string $type, $assets)
     {
         (is_array($assets)) ?
                         $this->assets[$type] = array_merge($this->assets[$type], $assets) :
@@ -208,7 +208,7 @@ class View
      * @param  array  $custom_assets Links dos arquivos que serão incluídos
      * @return string                HTML formatado de acordo com o tipo de arquivo
      */
-    private function assets($type, array $custom_assets = [])
+    private function assets(string $type, array $custom_assets = [])
     {
         $add_assets = '';
 
@@ -244,7 +244,7 @@ class View
 
         //Extract que transforma os parâmetros em variáveis disponíveis para a VIEW
         extract($data, EXTR_PREFIX_ALL, 'view');
-      
+
         //Variáveis
         $baseURI = $this->configs->baseURI;
         $viewsDir = $this->configs->views->directory;
@@ -257,7 +257,7 @@ class View
         define('IMG', $baseURI . 'public/img/');
         define('CSS', $baseURI . 'public/css/');
         define('JS', $baseURI . 'public/js/');
-        
+
         //Inclusão de ASSETS
         $add_css = $this->assets('css', $this->assets['css']);
         $add_js = $this->assets('js', $this->assets['js']);
@@ -290,7 +290,7 @@ class View
         exit();
     }
 
-    public function partial($view, array $params = [])
+    public function partial(string $view, array $params = [])
     {
         if (!empty($params))
             extract($params, EXTR_PREFIX_ALL, 'view');
@@ -305,14 +305,14 @@ class View
         require_once($viewFile);
     }
 
-    public function getRelativeURL($URL, $controller = true)
+    public function getRelativeURL(string $URL, bool $controller = true)
     {
         $path = $controller === true ? $this->path . DS : $this->subfolder;
 
         return $this->configs->baseURI . $path . $URL;
     }
 
-    public function printRelativeURL($URL, $controller = true)
+    public function printRelativeURL(string $URL, bool $controller = true)
     {
         $path = $controller === true ? $this->path . DS : $this->subfolder;
 

--- a/src/HXPHP/System/View.php
+++ b/src/HXPHP/System/View.php
@@ -214,11 +214,11 @@ class View
 
         switch ($type) {
             case 'css':
-                $tag = '<link type="text/css" rel="stylesheet" href="%s">' . "\n\r";
+                $tag = '<link type="text/css" rel="stylesheet" href="'.BASE.'%s">' . "\n\r";
                 break;
 
             case 'js':
-                $tag = '<script type="text/javascript" src="%s"></script>' . "\n\r";
+                $tag = '<script type="text/javascript" src="'.BASE.'%s"></script>' . "\n\r";
                 break;
         }
 
@@ -244,12 +244,7 @@ class View
 
         //Extract que transforma os parâmetros em variáveis disponíveis para a VIEW
         extract($data, EXTR_PREFIX_ALL, 'view');
-
-        //Inclusão de ASSETS
-
-        $add_css = $this->assets('css', $this->assets['css']);
-        $add_js = $this->assets('js', $this->assets['js']);
-
+      
         //Variáveis
         $baseURI = $this->configs->baseURI;
         $viewsDir = $this->configs->views->directory;
@@ -262,6 +257,10 @@ class View
         define('IMG', $baseURI . 'public/img/');
         define('CSS', $baseURI . 'public/css/');
         define('JS', $baseURI . 'public/js/');
+        
+        //Inclusão de ASSETS
+        $add_css = $this->assets('css', $this->assets['css']);
+        $add_js = $this->assets('js', $this->assets['js']);
 
         //Verifica a existência da VIEW
         $view = $viewsDir . $this->path . DS . $this->file . $viewsExt;


### PR DESCRIPTION
A função `assets()` gerava caminhos não relativos ao ambiente padrão. Esta atualização, corrige este problema, adicionado a constante `BASE`  e reordenando a atribuição dos `$add_js` e `$add_css`, para que os mesmos encontres as constantes já definidas.