### PR TITLE
Adicionado a capacidade de carregar Modulos e Environments apartir da pasta da aplicação

### DIFF
--- a/src/HXPHP/System/Configs/Environment.php
+++ b/src/HXPHP/System/Configs/Environment.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace HXPHP\System\Configs;
 
 use HXPHP\System\Tools;
@@ -19,15 +20,16 @@ class Environment
             $environment = $this->defaultEnvironment;
 
         $name = strtolower(Tools::filteredName($environment));
+        $app = 'APP\Environments\Environment' . ucfirst(Tools::filteredName($environment));
         $object = 'HXPHP\System\Configs\Environments\Environment' . ucfirst(Tools::filteredName($environment));
 
-        if (!class_exists($object))
-            throw new \Exception('O ambiente informado nao esta definido nas configuracoes do sistema.');
-
-        else {
+        if (class_exists($object)) {
             $this->$name = new $object();
-
             return $this->$name;
-        }
+        } elseif (class_exists($app)) {
+            $this->$name = new $app();
+            return $this->$name;
+        } else
+            throw new \Exception('O ambiente informado nao esta definido nas configuracoes do sistema.');
     }
 }

--- a/src/HXPHP/System/Configs/LoadModules.php
+++ b/src/HXPHP/System/Configs/LoadModules.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace HXPHP\System\Configs;
 
 use HXPHP\System\Tools;
@@ -18,12 +19,16 @@ class LoadModules
     {
         foreach ($this->modules as $module) {
             $module_class = Tools::filteredName(ucwords($module));
-            $object = 'HXPHP\System\Configs\Modules\\' . $module_class;
+            $app = 'APP\Modules\\'.$module_class.'\\'.$module_class.'Config';
+            $object = 'HXPHP\System\Configs\Modules\\'.$module_class;
 
-            if (!class_exists($object))
-                throw new \Exception("O modulo <'$object'> informado nao existe.", 1);
-            else
+            if (class_exists($object))
                 $obj->$module = new $object();
+            elseif (class_exists($app))
+                $obj->$module = new $app();
+            else
+                throw new \Exception("O modulo <'$object ou $app'> informado nao existe.", 1);
+
         }
         return $obj;
     }

--- a/src/HXPHP/System/Configs/RegisterModules.php
+++ b/src/HXPHP/System/Configs/RegisterModules.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace HXPHP\System\Configs;
 
 class RegisterModules
@@ -7,12 +8,21 @@ class RegisterModules
 
     public function __construct()
     {
-        $this->modules = [
+        $modules = [
             'database',
             'mail',
             'menu',
             'auth'
         ];
+
+        $appModules = 'App\\Modules\\Register';
+
+        if(class_exists($appModules)){
+            $register = new $appModules();
+            $modules = array_merge($modules,$register->modules);
+        }
+
+        $this->modules = $modules;
 
         return $this;
     }

--- a/src/HXPHP/System/Controller.php
+++ b/src/HXPHP/System/Controller.php
@@ -91,17 +91,29 @@ class Controller
          */
         $explode = explode('\\', $object);
         $object = $object . '\\' . end($explode);
-        $object = 'HXPHP\System\\' . $object;
+        $system = 'HXPHP\System\\' . $object;
+        $app = 'App\Modules\\' . $object;
 
-        if (class_exists($object)) {
+        if (class_exists($system)) {
             $name = end($explode);
             $name = strtolower(Tools::filteredName($name));
 
             if ($params) {
-                $ref = new \ReflectionClass($object);
+                $ref = new \ReflectionClass($system);
                 $this->view->$name = $ref->newInstanceArgs($params);
             } else
-                $this->view->$name = new $object();
+                $this->view->$name = new $system();
+
+            return $this->view->$name;
+        } elseif (class_exists($app)) {
+            $name = end($explode);
+            $name = strtolower(Tools::filteredName($name));
+
+            if ($params) {
+                $ref = new \ReflectionClass($app);
+                $this->view->$name = $ref->newInstanceArgs($params);
+            } else
+                $this->view->$name = new $app();
 
             return $this->view->$name;
         }


### PR DESCRIPTION
permitindo maior capacidade de personalizar o framework sem editar os arquivos originais.

Para environments necessário criar a pasta Environments dentro de app e colocar o arquivo dentro.

```php

namespace App\Environments;

use HXPHP\System\Configs as Configs;

class EnvironmentSite extends Configs\AbstractEnvironment
{
    function __construct()
    {
        parent::__construct();
    }
}
```

Para modulos necessário criar a pasta Modules dentro de app.

Criar o arquivo Register.php
```php

namespace App\Modules;

class Register
{

    public $modules = [];

    function __construct()
    {
        $this->modules = [];

        return $this;
    }

}
```

O modulo será carregado de acordo com o nome registrado no array, com uma pasta propria e dentro dessa pasta sera procurado o arquivo com o mesmo nome da pasta com a terminação "Config.php" para carregar as configurações do modulo.

Também passa a ser necessário modificar o namespace do modulo para se encaixar a nova estrutura de pasta e ser carregado pela função padrao de load do sistema.

```php

namespace App\Modules\{NomedoModulo};

```