### PR TITLE
Adição de tipagem de variáveis PHP 7

### DIFF
--- a/index.php
+++ b/index.php
@@ -22,8 +22,8 @@ $composer_autoload = 'vendor' . DS . 'autoload.php';
 if (!file_exists($composer_autoload))
     die('Execute o comando: composer install');
 
-if (version_compare(PHP_VERSION, '5.4.0', '<'))
-    die('Atualize seu PHP para a vers&atilde;o: 5.4.0 ou superior.');
+if (version_compare(PHP_VERSION, '7.0.0', '<'))
+    die('Atualize seu PHP para a vers&atilde;o: 7.0.0 ou superior.');
 
 require_once($composer_autoload);
 

--- a/src/HXPHP/System/Configs/AbstractEnvironment.php
+++ b/src/HXPHP/System/Configs/AbstractEnvironment.php
@@ -1,8 +1,6 @@
 <?php
 namespace HXPHP\System\Configs;
 
-use HXPHP\System\Configs\Modules as Modules;
-
 abstract class AbstractEnvironment
 {
     public $baseURI;

--- a/src/HXPHP/System/Configs/Config.php
+++ b/src/HXPHP/System/Configs/Config.php
@@ -15,7 +15,7 @@ class Config
         $this->env->add();
     }
 
-    public function __get($param)
+    public function __get(string $param)
     {
         $current = $this->define->getDefault();
 

--- a/src/HXPHP/System/Configs/DefineEnvironment.php
+++ b/src/HXPHP/System/Configs/DefineEnvironment.php
@@ -18,7 +18,7 @@ class DefineEnvironment
         return $this->currentEnviroment;
     }
 
-    public function setDefaultEnv($environment)
+    public function setDefaultEnv(string $environment)
     {
         $env = new Environment;
         if (is_object($env->add($environment)))

--- a/src/HXPHP/System/Configs/Environment.php
+++ b/src/HXPHP/System/Configs/Environment.php
@@ -13,7 +13,7 @@ class Environment
         $this->defaultEnvironment = $define->getDefault();
     }
 
-    public function add($environment = null)
+    public function add(string $environment = null)
     {
         if (!$environment)
             $environment = $this->defaultEnvironment;

--- a/src/HXPHP/System/Configs/Modules/Auth.php
+++ b/src/HXPHP/System/Configs/Modules/Auth.php
@@ -6,7 +6,7 @@ class Auth
     public $after_login = null;
     public $after_logout = null;
 
-    public function setURLs($after_login, $after_logout, $subfolder = 'default')
+    public function setURLs(string $after_login, string $after_logout, string $subfolder = 'default')
     {
         $this->after_login[$subfolder] = $after_login;
         $this->after_logout[$subfolder] = $after_logout;

--- a/src/HXPHP/System/Configs/Modules/Menu.php
+++ b/src/HXPHP/System/Configs/Modules/Menu.php
@@ -32,7 +32,7 @@ class Menu
         return $this->configs = array_merge($this->configs, $configs);
     }
 
-    public function setMenus(array $itens, $role = 'default')
+    public function setMenus(array $itens, string $role = 'default')
     {
         return $this->itens[$role] = $itens;
     }

--- a/src/HXPHP/System/Controller.php
+++ b/src/HXPHP/System/Controller.php
@@ -29,13 +29,13 @@ class Controller
      */
     public $view;
 
-    public function __construct($configs = null)
+    public function __construct(Configs\Config $configs = null)
     {
         //Injeção da VIEW
         $this->view = new View;
         $this->response = new Http\Response;
 
-        if ($configs && $configs instanceof Configs\Config)
+        if ($configs)
             $this->setConfigs($configs);
     }
 
@@ -112,7 +112,7 @@ class Controller
      * @param  string $param Atributo
      * @return mixed         Conteúdo do atributo ou Exception
      */
-    public function __get($param)
+    public function __get(string $param)
     {
         if (isset($this->view->$param))
             return $this->view->$param;
@@ -129,7 +129,7 @@ class Controller
      * @param  boolean $controller Define se o controller também será retornado
      * @return string              Link relativo
      */
-    public function getRelativeURL($URL, $controller = true)
+    public function getRelativeURL(string $URL, bool $controller = true)
     {
         $path = $controller === true ? $this->view->path . DS : $this->view->subfolder;
 
@@ -142,7 +142,7 @@ class Controller
      * @param  boolean $external Define se o redirecionamento será relativo ou absoluto
      * @param  boolean $controller Define se o controller também será retornado
      */
-    public function redirectTo($URL, $external = true, $controller = true)
+    public function redirectTo(string $URL, bool $external = true, bool $controller = true)
     {
         $URL = $external === false ? $this->getRelativeURL($URL, $controller) : $URL;
         return $this->response->redirectTo($URL);

--- a/src/HXPHP/System/Helpers/Alert/Template.php
+++ b/src/HXPHP/System/Helpers/Alert/Template.php
@@ -12,14 +12,14 @@ class Template
                 ->setTemplateFile('alert');
     }
 
-    public function setTemplatePath($path)
+    public function setTemplatePath(string $path)
     {
         $this->template_path = $path;
 
         return $this;
     }
 
-    public function setTemplateFile($file)
+    public function setTemplateFile(string $file)
     {
         $this->template_file = $file;
 
@@ -30,7 +30,7 @@ class Template
      * Método resposnável pela obtenção do conteúdo do template
      * @return html
      */
-    public function get($list = false)
+    public function get(bool $list = false)
     {
         if ($list)
             $this->setTemplateFile('alert-list');

--- a/src/HXPHP/System/Helpers/Menu/Attrs.php
+++ b/src/HXPHP/System/Helpers/Menu/Attrs.php
@@ -8,7 +8,7 @@ class Attrs
      * @param  array  $attrs Atributos
      * @return string        Atributos no formato HTML
      */
-    public static function render($attrs)
+    public static function render(array $attrs)
     {
         if (!$attrs || !is_array($attrs))
             return null;
@@ -17,7 +17,6 @@ class Attrs
 
         foreach ($attrs as $attr => $value)
             $html .= ' ' . $attr . '="' . $value . '" ';
-
 
         return $html;
     }

--- a/src/HXPHP/System/Helpers/Menu/CheckActive.php
+++ b/src/HXPHP/System/Helpers/Menu/CheckActive.php
@@ -15,7 +15,7 @@ class CheckActive
      */
     private $current_URL = null;
 
-    public function __construct(RealLink $realLink, $current_URL)
+    public function __construct(RealLink $realLink, string $current_URL)
     {
         $this->realLink = $realLink;
         $this->current_URL = $current_URL;
@@ -23,10 +23,10 @@ class CheckActive
 
     /**
      * Verifica se o link está ativo
-     * @param  string $URL Link do menuy
+     * @param  string $URL Link do menu
      * @return bool        Status do link
      */
-    public function link($URL)
+    public function link(string $URL)
     {
         $position = strpos($this->current_URL, $URL);
         return $this->current_URL === $URL || ($position && $position > 0) ? true : false;

--- a/src/HXPHP/System/Helpers/Menu/Elements.php
+++ b/src/HXPHP/System/Helpers/Menu/Elements.php
@@ -3,11 +3,12 @@ namespace HXPHP\System\Helpers\Menu;
 
 class Elements
 {
+
     /**
      * Elementos HTML utilizados na renderização do menu
      * @var array
      */
-    private static $elements = array(
+    private static $elements = [
         /**
          * Tag inicio container
          * ID
@@ -73,7 +74,7 @@ class Elements
          * Conteúdo
          */
         'dropdown_item' => '<li class="%s %s">%s</li>'
-    );
+    ];
 
     /**
      * Retorna um elemento
@@ -81,7 +82,7 @@ class Elements
      * @param  array  $args Array para preencher os coringas presentes nos elementos
      * @return string       HTML do elemento
      */
-    public static function get($name, array $args = [])
+    public static function get(string $name, array $args = [])
     {
         if (!self::$elements[$name])
             return false;

--- a/src/HXPHP/System/Helpers/Menu/Menu.php
+++ b/src/HXPHP/System/Helpers/Menu/Menu.php
@@ -1,6 +1,9 @@
 <?php
 namespace HXPHP\System\Helpers\Menu;
 
+use HXPHP\System\Configs\Config;
+use HXPHP\System\Http\Request;
+
 class Menu
 {
     /**
@@ -28,11 +31,11 @@ class Menu
     private $role;
 
     /**
-     * @param \HXPHP\System\Http\Request   $request Objeto Request
-     * @param \HXPHP\System\Configs\Config $configs Configurações do framework
-     * @param string                       $role    Nível de acesso
+     * @param Request $request Objeto Request
+     * @param Config  $configs Configurações do framework
+     * @param string  $role    Nível de acesso
      */
-    public function __construct(\HXPHP\System\Http\Request $request, \HXPHP\System\Configs\Config $configs, $role = 'default')
+    public function __construct(Request $request, Config $configs, string $role = 'default')
     {
         $this->role = $role;
 
@@ -51,7 +54,7 @@ class Menu
      * Dados do módulo de configuração do MenuHelper
      * @param array $configs
      */
-    private function setConfigs($configs)
+    private function setConfigs(Config $configs)
     {
         $this->configs = $configs;
 
@@ -61,7 +64,7 @@ class Menu
     /**
      * Define a URL atual
      */
-    private function setCurrentURL($request, $configs)
+    private function setCurrentURL(Request $request, Config $configs)
     {
         $parseURL = parse_url($request->server('REQUEST_URI'));
 

--- a/src/HXPHP/System/Helpers/Menu/MenuData.php
+++ b/src/HXPHP/System/Helpers/Menu/MenuData.php
@@ -8,7 +8,7 @@ class MenuData
      * @param  string $key Titulo/Icone
      * @return object      Objeto com dados extraídos
      */
-    public static function get($key)
+    public static function get(string $key)
     {
         $obj = new \stdClass;
 

--- a/src/HXPHP/System/Helpers/Menu/RealLink.php
+++ b/src/HXPHP/System/Helpers/Menu/RealLink.php
@@ -6,7 +6,7 @@ class RealLink
     private $siteURL;
     private $baseURI;
 
-    public function __construct($siteURL, $baseURI)
+    public function __construct(string $siteURL, string $baseURI)
     {
         $this->siteURL = $siteURL;
         $this->baseURI = $baseURI;

--- a/src/HXPHP/System/Helpers/Menu/Render.php
+++ b/src/HXPHP/System/Helpers/Menu/Render.php
@@ -24,7 +24,7 @@ class Render
     private $html;
 
     public function __construct(
-    RealLink $realLink, CheckActive $checkActive, $menu_itens, $menu_configs
+    RealLink $realLink, CheckActive $checkActive, array $menu_itens, array $menu_configs
     )
     {
         $this->realLink = $realLink;
@@ -37,7 +37,7 @@ class Render
     /**
      * Renderiza o menu em HTML
      */
-    public function getHTML($role = 'default')
+    public function getHTML(string $role = 'default')
     {
         $menu_itens = ($this->menu_itens[$role]) ? $this->menu_itens[$role] : [];
         $menu_configs = $this->menu_configs;

--- a/src/HXPHP/System/Http/Request.php
+++ b/src/HXPHP/System/Http/Request.php
@@ -23,7 +23,7 @@ class Request
     /**
      * Método construtor
      */
-    public function __construct($baseURI = '', $controller_directory = '')
+    public function __construct(string $baseURI = '', string $controller_directory = '')
     {
         $this->subfolder = 'default';
         $this->initialize($baseURI, $controller_directory);
@@ -34,7 +34,7 @@ class Request
      * Define os parâmetros do mecanismo MVC
      * @return object Retorna o objeto com as propriedades definidas
      */
-    public function initialize($baseURI, $controller_directory)
+    public function initialize(string $baseURI, string $controller_directory)
     {
         if (!empty($baseURI) && !empty($controller_directory)) {
             $explode = array_values(array_filter(explode('/', $_SERVER['REQUEST_URI'])));
@@ -116,7 +116,7 @@ class Request
      * @param  string $name Nome do parâmetro
      * @return null         Retorna o array GET geral ou em um índice específico
      */
-    public function get($name = null)
+    public function get(string $name = null)
     {
         $get = $this->filter($_GET, INPUT_GET, $this->custom_filters);
 
@@ -136,7 +136,7 @@ class Request
      * @param  string $name Nome do parâmetro
      * @return null         Retorna o array POST geral ou em um índice específico
      */
-    public function post($name = null)
+    public function post(string $name = null)
     {
         $post = $this->filter($_POST, INPUT_POST, $this->custom_filters);
 
@@ -155,7 +155,7 @@ class Request
      * @param  string $name Nome do parâmetro
      * @return null         Retorna o array $_SERVER geral ou em um índice específico
      */
-    public function server($name = null)
+    public function server(string $name = null)
     {
         $server = $this->filter($_SERVER, INPUT_SERVER, $this->custom_filters);
 
@@ -176,7 +176,7 @@ class Request
      * @param string $name Nome do parâmetro
      * @return null Retorna o array $_COOKIE geral ou em um índice específico
      */
-    public function cookie($name = null)
+    public function cookie(string $name = null)
     {
         $cookie = $this->filter($_COOKIE, INPUT_COOKIE, $this->custom_filters);
 
@@ -194,7 +194,7 @@ class Request
      * @param  string $value Nome do método
      * @return null          Retorna um booleano ou o método em si
      */
-    public function getMethod($value = null)
+    public function getMethod(string $value = null)
     {
         $method = $_SERVER['REQUEST_METHOD'];
 

--- a/src/HXPHP/System/Http/Response.php
+++ b/src/HXPHP/System/Http/Response.php
@@ -8,14 +8,14 @@ class Response
      * Redirecionamento
      * @param  string $url URL para aonde a aplicação deve ser redirecionada
      */
-    public function redirectTo($url)
+    public function redirectTo(string $url)
     {
         $this->header('location: ' . $url);
 
         exit();
     }
 
-    public function header($header)
+    public function header(string $header)
     {
         header($header);
     }

--- a/src/HXPHP/System/Model.php
+++ b/src/HXPHP/System/Model.php
@@ -10,7 +10,7 @@ class Model extends \ActiveRecord\Model
      * @param boolean $instantiating_via_find Atributo obrigatório do PHP ActiveRecord
      * @param boolean $new_record             Atributo obrigatório do PHP ActiveRecord
      */
-    public function __construct($attributes = [], $guard_attributes = TRUE, $instantiating_via_find = FALSE, $new_record = TRUE)
+    public function __construct(array $attributes = [], bool $guard_attributes = true, bool $instantiating_via_find = false, bool $new_record = true)
     {
         parent::__construct($attributes, $guard_attributes, $instantiating_via_find, $new_record);
 

--- a/src/HXPHP/System/Modules/Messages/LoadTemplate.php
+++ b/src/HXPHP/System/Modules/Messages/LoadTemplate.php
@@ -21,7 +21,7 @@ class LoadTemplate
      * Método responsável pela leitura do arquivo JSON
      * @param string $template Nome do template
      */
-    public function __construct($template, $extension = '.json')
+    public function __construct(string $template, string $extension = '.json')
     {
         /**
          * Caminho completo do template

--- a/src/HXPHP/System/Modules/Messages/Messages.php
+++ b/src/HXPHP/System/Modules/Messages/Messages.php
@@ -25,7 +25,7 @@ class Messages
      * Método construtor
      * @param string $template Nome do arquivo que encontra-se na sub-pasta 'templates'
      */
-    public function __construct($file)
+    public function __construct(string $file)
     {
         /**
          * Recebe o conteúdo JSON do template definido
@@ -48,7 +48,7 @@ class Messages
      * Altera o bloco padrão
      * @param string $block
      */
-    public function setBlock($block)
+    public function setBlock(string $block)
     {
         $this->block = $block;
         return $this;
@@ -60,7 +60,7 @@ class Messages
      * @param  string $method getByCode()
      * @param  array  $args   Argumentos passados para o método
      */
-    public function __call($method, $args)
+    public function __call(string $method, array $args)
     {
         $block = $this->block;
 
@@ -75,7 +75,7 @@ class Messages
      * @param  string $block Nome do bloco
      * @return object        Instância do objeto Template
      */
-    public function __get($block)
+    public function __get(string $block)
     {
         if ($this->content[$block]) {
             $this->$block = new Template($this->content[$block]);

--- a/src/HXPHP/System/Modules/Messages/Template.php
+++ b/src/HXPHP/System/Modules/Messages/Template.php
@@ -9,7 +9,7 @@ class Template
      */
     private $content;
 
-    public function __construct($content)
+    public function __construct(array $content)
     {
         $this->content = $content;
     }
@@ -20,7 +20,7 @@ class Template
      * @param  array  $fields Fields e seus parâmetros para substituição
      * @return array
      */
-    public function getByCode($code, array $fields = [])
+    public function getByCode(string $code, array $fields = [])
     {
         if ($this->content[$code]) {
             $output = $this->content[$code];

--- a/src/HXPHP/System/Services/Auth/Auth.php
+++ b/src/HXPHP/System/Services/Auth/Auth.php
@@ -31,7 +31,7 @@ class Auth
     /**
      * Método construtor
      */
-    public function __construct($after_login, $after_logout, $redirect = false, $subfolder = 'default')
+    public function __construct(array $after_login, array $after_logout, bool $redirect = false, string $subfolder = 'default')
     {
         //Instância dos objetos injetados
         $this->request = new Http\Request;
@@ -57,7 +57,7 @@ class Auth
      * @param  string $username  Nome de usuário
      * @param string $user_role Role do usuário
      */
-    public function login($user_id, $username, $user_role = null)
+    public function login(int $user_id, string $username, string $user_role = null)
     {
         $user_id = intval(preg_replace("/[^0-9]+/", "", $user_id));
         $username = preg_replace("/[^a-zA-Z0-9_\-]+/", "", $username);
@@ -93,7 +93,7 @@ class Auth
      * Valida a autenticação e redireciona mediante o estado do usuário
      * @param  boolean $redirect Parâmetro que define se é uma página pública ou não
      */
-    public function redirectCheck($redirect = false)
+    public function redirectCheck(bool $redirect = false)
     {
         if ($redirect && $this->login_check())
             $this->response->redirectTo($this->url_redirect_after_login);

--- a/src/HXPHP/System/Services/Email/Email.php
+++ b/src/HXPHP/System/Services/Email/Email.php
@@ -21,7 +21,7 @@ class Email
      * @param  bool   $accept_html Define se a mensagem será enviada em TXT ou HTML
      * @return bool             Status de envio e mensagem
      */
-    public function send($to, $subject, $message, array $from = [], $accept_html = true)
+    public function send(string $to, string $subject, string $message, array $from = [], bool $accept_html = true)
     {
         $to = strtolower($to);
         $subject = addslashes(trim($subject));

--- a/src/HXPHP/System/Services/PasswordRecovery/PasswordRecovery.php
+++ b/src/HXPHP/System/Services/PasswordRecovery/PasswordRecovery.php
@@ -19,7 +19,7 @@ class PasswordRecovery
      * Define o link
      * @param string $link Prefixo do link c/ barra no final Ex.: http://www.site.com.br/esqueci-a-senha/redefinir/
      */
-    public function __construct($link)
+    public function __construct(string $link)
     {
         $this->setLink($link);
     }
@@ -36,7 +36,7 @@ class PasswordRecovery
      * Define o link
      * @param string $link Prefixo do link c/ barra no final
      */
-    public function setLink($link)
+    public function setLink(string $link)
     {
         $this->generateToken();
         $this->link = $link . $this->token;

--- a/src/HXPHP/System/Services/SimplecURL/SimplecURL.php
+++ b/src/HXPHP/System/Services/SimplecURL/SimplecURL.php
@@ -3,7 +3,7 @@ namespace HXPHP\System\Services\SimplecURL;
 
 class SimplecURL
 {
-    public static function connect($url, array $post = [], array $get = [])
+    public static function connect(string $url, array $post = [], array $get = [])
     {
         $url = explode('?', $url, 2);
 

--- a/src/HXPHP/System/Services/StartSession/StartSession.php
+++ b/src/HXPHP/System/Services/StartSession/StartSession.php
@@ -8,7 +8,7 @@ class StartSession
      * @param  boolean $regenerate Regerar sessão após start
      * @return void
      */
-    static function sec_session_start($regenerate = false)
+    static function sec_session_start(bool $regenerate = false)
     {
         ini_set('session.use_only_cookies', 1);
 

--- a/src/HXPHP/System/Storage/Cookie/Cookie.php
+++ b/src/HXPHP/System/Storage/Cookie/Cookie.php
@@ -9,7 +9,7 @@ class Cookie implements \HXPHP\System\Storage\StorageInterface
      * @param string $value Conteúdo do cookie
      * @param timestamp $time Tempo de duração do cookie
      */
-    public function set($name, $value, $time = 31556926)
+    public function set(string $name, string $value, int $time = 31556926)
     {
         $cookieParams = session_get_cookie_params();
 
@@ -23,7 +23,7 @@ class Cookie implements \HXPHP\System\Storage\StorageInterface
      * @param  string $name Nome do cookie
      * @return string       Conteúdo do cookie
      */
-    public function get($name)
+    public function get(string $name)
     {
         if ($this->exists($name))
             return $_COOKIE[$name];
@@ -36,7 +36,7 @@ class Cookie implements \HXPHP\System\Storage\StorageInterface
      * @param  string  $name Nome do cookie
      * @return boolean       Status do processo
      */
-    public function exists($name)
+    public function exists(string $name)
     {
         return isset($_COOKIE[$name]);
     }
@@ -45,9 +45,9 @@ class Cookie implements \HXPHP\System\Storage\StorageInterface
      * Exclui um cookie
      * @param  string $name Nome do cookie
      */
-    public function clear($name)
+    public function clear(string $name)
     {
         if ($this->exists($name))
-            return $this->set($name, NULL, -1);
+            return $this->set($name, '', -1);
     }
 }

--- a/src/HXPHP/System/Storage/Session/Session.php
+++ b/src/HXPHP/System/Storage/Session/Session.php
@@ -14,7 +14,7 @@ class Session implements \HXPHP\System\Storage\StorageInterface
      * @param string $value Conteúdo da sessão
      * @param int $timeout  Tempo de expiração da sessão
      */
-    public function set($name, $value, $timeout = null)
+    public function set(string $name, string $value, int $timeout = null)
     {
         $_SESSION[self::PREFIX][$name] = $value;
 
@@ -31,7 +31,7 @@ class Session implements \HXPHP\System\Storage\StorageInterface
      * @param  string $name Nome da sessão
      * @return string       Conteúdo da sessão
      */
-    public function get($name)
+    public function get(string $name)
     {
         if ($this->exists($name)) {
             if (!$this->hasExpired($name))
@@ -48,7 +48,7 @@ class Session implements \HXPHP\System\Storage\StorageInterface
      * @param  string  $name Nome da sessão
      * @return boolean       Status do processo
      */
-    public function exists($name)
+    public function exists(string $name)
     {
         return isset($_SESSION[self::PREFIX][$name]);
     }
@@ -58,7 +58,7 @@ class Session implements \HXPHP\System\Storage\StorageInterface
      * @param string $name   Nome da sessão
      * @return boolean       Sessão expirada ou não
      */
-    public function hasExpired($name)
+    public function hasExpired(string $name)
     {
         if (!$this->exists($name . '_timeout'))
             return false;
@@ -75,7 +75,7 @@ class Session implements \HXPHP\System\Storage\StorageInterface
      * @param string $name   Nome da sessão
      * @return date          Quantidade de tempo restante para o timeout
      */
-    public function getTimeLeftOf($name)
+    public function getTimeLeftOf(string $name)
     {
         if ($this->hasExpired($name))
             return 0;
@@ -87,7 +87,7 @@ class Session implements \HXPHP\System\Storage\StorageInterface
      * Exclui uma sessão
      * @param  string $name Nome da sessão
      */
-    public function clear($name)
+    public function clear(string $name)
     {
         if ($this->exists($name))
             unset($_SESSION[self::PREFIX][$name]);

--- a/src/HXPHP/System/Storage/StorageInterface.php
+++ b/src/HXPHP/System/Storage/StorageInterface.php
@@ -9,29 +9,26 @@ interface StorageInterface
      * @param string $name  Nome do indice para o valor
      * @param $this
      */
-    public function set($name, $value);
-
+    public function set(string $name, string $value);
     /**
      * Usar para resgatar um valor no storage
      *
      * @param  string $name Nome do indice que o valor foi armazenado
      * @return *
      */
-    public function get($name);
-
+    public function get(string $name);
     /**
      * Usar para verificar se um indice existe no storage
      *
      * @param  string $name
      * @return boolean
      */
-    public function exists($name);
-
+    public function exists(string $name);
     /**
      * Usar para apagar um indice do storage
      *
      * @param  string $name
      * @return boolean
      */
-    public function clear($name);
+    public function clear(string $name);
 }

--- a/src/HXPHP/System/Tools.php
+++ b/src/HXPHP/System/Tools.php
@@ -7,7 +7,7 @@ class Tools
      * Exibe os dados
      * @param  mist $data Variável que será "debugada"
      */
-    public static function dd($data, $dump = false)
+    public static function dd($data, bool $dump = true)
     {
         echo '<pre>';
 
@@ -16,7 +16,7 @@ class Tools
         echo '</pre>';
     }
 
-    public static function getTemplatePath($component, $name, $templateFile)
+    public static function getTemplatePath(string $component, string $name, string $templateFile)
     {
         $templatePath = TEMPLATES_PATH . $component . DS . $name . DS . $templateFile;
 
@@ -32,9 +32,8 @@ class Tools
      * @param  string $salt     Código alfanumérico
      * @return array            Array com o SALT e a SENHA
      */
-    public static function hashHX($password, $salt = null)
+    public static function hashHX(string $password, string $salt = null)
     {
-
         if (!$salt)
             $salt = hash('sha512', uniqid(mt_rand(1, mt_getrandmax()), true));
 
@@ -51,7 +50,7 @@ class Tools
      * @param string $input     String que será convertida
      * @return string           String convertida
      */
-    public static function filteredName($input)
+    public static function filteredName(string $input)
     {
         $input = explode('?', $input);
         $input = $input[0];
@@ -67,7 +66,7 @@ class Tools
         return str_replace(' ', '', ucwords(str_replace($find, $replace, $input)));
     }
 
-    public static function filteredFileName($input)
+    public static function filteredFileName(string $input)
     {
         $input = trim($input);
 
@@ -185,7 +184,7 @@ class Tools
         return strtolower(str_replace(' ', '_', str_replace($find, $replace, $new)));
     }
 
-    public static function decamelize($cameled, $sep = '-')
+    public static function decamelize(string $cameled, string $sep = '-')
     {
         return implode(
                 $sep, array_map(

--- a/src/HXPHP/System/View.php
+++ b/src/HXPHP/System/View.php
@@ -38,7 +38,7 @@ class View
         'js' => []
     ];
 
-    public function setConfigs(Configs\Config $configs, $subfolder, $controller, $action)
+    public function setConfigs(Configs\Config $configs, string $subfolder, string $controller, string $action)
     {
         /**
          * Injeção das Configurações
@@ -97,7 +97,7 @@ class View
      * Define o diretório das views parciais
      * @param string  $partialsDir  Diretório
      */
-    public function setPartialsDir($partialsDir, $overwrite = false)
+    public function setPartialsDir(string $partialsDir, bool $overwrite = false)
     {
         $viewsDir = $this->configs->views->directory;
 
@@ -111,7 +111,7 @@ class View
      * Define o título da página
      * @param string  $title  Título da página
      */
-    public function setTitle($title)
+    public function setTitle(string $title)
     {
         $this->title = $title;
         return $this;
@@ -121,7 +121,7 @@ class View
      * Define a pasta da view
      * @param string  $path  Caminho da View
      */
-    public function setPath($path, $overwrite = false)
+    public function setPath(string $path, bool $overwrite = false)
     {
         $this->path = $overwrite === false ? $this->subfolder . $path : $path;
         return $this;
@@ -131,7 +131,7 @@ class View
      * Define se o arquivo é miolo (Inclusão de Cabeçalho e Rodapé) ou único
      * @param bool  $template  Template ON/OFF
      */
-    public function setTemplate($template)
+    public function setTemplate(bool $template)
     {
         $this->template = $template;
         return $this;
@@ -141,7 +141,7 @@ class View
      * Define o cabeçalho da view
      * @param string  $header  Cabeçalho da View
      */
-    public function setHeader($header, $overwrite = false)
+    public function setHeader(string $header, bool $overwrite = false)
     {
         $this->header = $overwrite === false ? $this->subfolder . $header : $header;
         return $this;
@@ -151,7 +151,7 @@ class View
      * Define o arquivo da view
      * @param string  $file  Arquivo da View
      */
-    public function setFile($file)
+    public function setFile(string $file)
     {
         $this->file = $file;
         return $this;
@@ -161,7 +161,7 @@ class View
      * Define o rodapé da view
      * @param string  $footer  Rodapé da View
      */
-    public function setFooter($footer, $overwrite = false)
+    public function setFooter(string $footer, bool $overwrite = false)
     {
         $this->footer = $overwrite === false ? $this->subfolder . $footer : $footer;
         return $this;
@@ -182,7 +182,7 @@ class View
      * @param string  $name  Nome do índice
      * @param string  $value  Valor
      */
-    public function setVar($name, $value)
+    public function setVar(string $name, $value)
     {
         $this->vars[$name] = $value;
         return $this;
@@ -193,7 +193,7 @@ class View
      * @param string  $type  Tipo do arquivo
      * @param string|array  $assets  Arquivo Único | Array com os arquivos
      */
-    public function setAssets($type, $assets)
+    public function setAssets(string $type, $assets)
     {
         (is_array($assets)) ?
                         $this->assets[$type] = array_merge($this->assets[$type], $assets) :
@@ -208,7 +208,7 @@ class View
      * @param  array  $custom_assets Links dos arquivos que serão incluídos
      * @return string                HTML formatado de acordo com o tipo de arquivo
      */
-    private function assets($type, array $custom_assets = [])
+    private function assets(string $type, array $custom_assets = [])
     {
         $add_assets = '';
 
@@ -291,7 +291,7 @@ class View
         exit();
     }
 
-    public function partial($view, array $params = [])
+    public function partial(string $view, array $params = [])
     {
         if (!empty($params))
             extract($params, EXTR_PREFIX_ALL, 'view');
@@ -306,14 +306,14 @@ class View
         require($viewFile);
     }
 
-    public function getRelativeURL($URL, $controller = true)
+    public function getRelativeURL(string $URL, bool $controller = true)
     {
         $path = $controller === true ? $this->path . DS : $this->subfolder;
 
         return $this->configs->baseURI . $path . $URL;
     }
 
-    public function printRelativeURL($URL, $controller = true)
+    public function printRelativeURL(string $URL, bool $controller = true)
     {
         $path = $controller === true ? $this->path . DS : $this->subfolder;
 


### PR DESCRIPTION
Olá @brunosantoshx, tudo bem?

Como conversamos, gostaria de migrar o HXPHP Framework para a versão 7 do PHP, devido aos grandes avanço dessa atualização da linguagem.

Neste PR, faço a [tipagem de variável](http://php.net/manual/pt_BR/functions.arguments.php#functions.arguments.type-declaration), algo que incrementa performance e segurança ao framework.

PS: para alterações fora do contexto, foram adicionados comentários extras.

Abraços!