### PR TITLE
Declaração de tipo de retorno PHP 7

### DIFF
--- a/src/HXPHP/System/Configs/DefineEnvironment.php
+++ b/src/HXPHP/System/Configs/DefineEnvironment.php
@@ -25,7 +25,7 @@ class DefineEnvironment
             $this->currentEnviroment = $environment;
     }
     
-    public function getDefault()
+    public function getDefault(): string
     {
         return $this->currentEnviroment;
     }
@@ -33,7 +33,7 @@ class DefineEnvironment
 
 trait CurrentEnviroment
 {
-    public function getCurrentEnvironment()
+    public function getCurrentEnvironment(): string
     {
         $default = new DefineEnvironment;
         return $default->getDefault();

--- a/src/HXPHP/System/Configs/Modules/Auth.php
+++ b/src/HXPHP/System/Configs/Modules/Auth.php
@@ -6,7 +6,7 @@ class Auth
     public $after_login = null;
     public $after_logout = null;
 
-    public function setURLs(string $after_login, string $after_logout, string $subfolder = 'default')
+    public function setURLs(string $after_login, string $after_logout, string $subfolder = 'default'): self
     {
         $this->after_login[$subfolder] = $after_login;
         $this->after_logout[$subfolder] = $after_logout;

--- a/src/HXPHP/System/Configs/Modules/Database.php
+++ b/src/HXPHP/System/Configs/Modules/Database.php
@@ -23,7 +23,7 @@ class Database
         return $this;
     }
 
-    public function setConnectionData(array $data)
+    public function setConnectionData(array $data): self
     {
         foreach ($data as $param => $value) {
 

--- a/src/HXPHP/System/Configs/Modules/Mail.php
+++ b/src/HXPHP/System/Configs/Modules/Mail.php
@@ -15,7 +15,7 @@ class Mail
         return $this;
     }
 
-    public function setFrom(array $data)
+    public function setFrom(array $data): self
     {
         $this->from = $data['from'];
         $this->from_mail = $data['from_mail'];
@@ -23,7 +23,7 @@ class Mail
         return $this;
     }
 
-    public function getFrom()
+    public function getFrom(): array
     {
         return [
             'from_mail' => $this->from_mail,

--- a/src/HXPHP/System/Configs/Modules/Menu.php
+++ b/src/HXPHP/System/Configs/Modules/Menu.php
@@ -27,12 +27,12 @@ class Menu
     
     public $itens = [];
 
-    public function setConfigs(array $configs)
+    public function setConfigs(array $configs): array
     {
         return $this->configs = array_merge($this->configs, $configs);
     }
 
-    public function setMenus(array $itens, string $role = 'default')
+    public function setMenus(array $itens, string $role = 'default'): array
     {
         return $this->itens[$role] = $itens;
     }

--- a/src/HXPHP/System/Controller.php
+++ b/src/HXPHP/System/Controller.php
@@ -44,7 +44,7 @@ class Controller
      * @param  Config $configs Objeto com as configurações da aplicação
      * @return object
      */
-    public function setConfigs(Configs\Config $configs)
+    public function setConfigs(Configs\Config $configs): self
     {
         //Injeção das dependências
         $this->configs = $configs;
@@ -129,7 +129,7 @@ class Controller
      * @param  boolean $controller Define se o controller também será retornado
      * @return string              Link relativo
      */
-    public function getRelativeURL(string $URL, bool $controller = true)
+    public function getRelativeURL(string $URL, bool $controller = true): string
     {
         $path = $controller === true ? $this->view->path . DS : $this->view->subfolder;
 

--- a/src/HXPHP/System/Helpers/Alert/Alert.php
+++ b/src/HXPHP/System/Helpers/Alert/Alert.php
@@ -57,7 +57,7 @@ class Alert
      * Retorna os alertas da aplicação
      * @return html
      */
-    public function getAlert()
+    public function getAlert(): string
     {
         $message = $this->storage->get('message');
         $this->storage->clear('message');
@@ -69,7 +69,7 @@ class Alert
      * Retorna os alertas da aplicação
      * @return html
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getAlert();
     }

--- a/src/HXPHP/System/Helpers/Alert/Render.php
+++ b/src/HXPHP/System/Helpers/Alert/Render.php
@@ -8,7 +8,7 @@ class Render
      * @param  array|string $messages Mensagem pode ser um array com a seguinte estrutura ['Erro' => 'Justicativa' , 'Erro 2' => 'Justificativa 2'] ou uma string
      * @return mixed
      */
-    public function get($messages)
+    public function get($messages): string
     {
         if (!is_array($messages))
             return $messages;

--- a/src/HXPHP/System/Helpers/Alert/Template.php
+++ b/src/HXPHP/System/Helpers/Alert/Template.php
@@ -12,14 +12,14 @@ class Template
                 ->setTemplateFile('alert');
     }
 
-    public function setTemplatePath(string $path)
+    public function setTemplatePath(string $path): self
     {
         $this->template_path = $path;
 
         return $this;
     }
 
-    public function setTemplateFile(string $file)
+    public function setTemplateFile(string $file): self
     {
         $this->template_file = $file;
 
@@ -30,7 +30,7 @@ class Template
      * Método resposnável pela obtenção do conteúdo do template
      * @return html
      */
-    public function get(bool $list = false)
+    public function get(bool $list = false): string
     {
         if ($list)
             $this->setTemplateFile('alert-list');

--- a/src/HXPHP/System/Helpers/Menu/Attrs.php
+++ b/src/HXPHP/System/Helpers/Menu/Attrs.php
@@ -8,7 +8,7 @@ class Attrs
      * @param  array  $attrs Atributos
      * @return string        Atributos no formato HTML
      */
-    public static function render(array $attrs)
+    public static function render(array $attrs): string
     {
         if (!$attrs || !is_array($attrs))
             return null;

--- a/src/HXPHP/System/Helpers/Menu/CheckActive.php
+++ b/src/HXPHP/System/Helpers/Menu/CheckActive.php
@@ -26,7 +26,7 @@ class CheckActive
      * @param  string $URL Link do menu
      * @return bool        Status do link
      */
-    public function link(string $URL)
+    public function link(string $URL): bool
     {
         $position = strpos($this->current_URL, $URL);
         return $this->current_URL === $URL || ($position && $position > 0) ? true : false;
@@ -37,7 +37,7 @@ class CheckActive
      * @param  array $values Links do dropdown
      * @return bool        	 Status do dropdown
      */
-    public function dropdown(array $values)
+    public function dropdown(array $values): bool
     {
         $values = array_values($values);
         $status = false;

--- a/src/HXPHP/System/Helpers/Menu/Elements.php
+++ b/src/HXPHP/System/Helpers/Menu/Elements.php
@@ -82,7 +82,7 @@ class Elements
      * @param  array  $args Array para preencher os coringas presentes nos elementos
      * @return string       HTML do elemento
      */
-    public static function get(string $name, array $args = [])
+    public static function get(string $name, array $args = []): string
     {
         if (!self::$elements[$name])
             return false;

--- a/src/HXPHP/System/Helpers/Menu/Menu.php
+++ b/src/HXPHP/System/Helpers/Menu/Menu.php
@@ -54,7 +54,7 @@ class Menu
      * Dados do módulo de configuração do MenuHelper
      * @param array $configs
      */
-    private function setConfigs(Config $configs)
+    private function setConfigs(Config $configs): self
     {
         $this->configs = $configs;
 
@@ -64,7 +64,7 @@ class Menu
     /**
      * Define a URL atual
      */
-    private function setCurrentURL(Request $request, Config $configs)
+    private function setCurrentURL(Request $request, Config $configs): self
     {
         $parseURL = parse_url($request->server('REQUEST_URI'));
 
@@ -77,7 +77,7 @@ class Menu
      * Exibe o HTML com o menu renderizado
      * @return string
      */
-    public function getMenu()
+    public function getMenu(): string
     {
         return $this->render->getHTML($this->role);
     }
@@ -86,7 +86,7 @@ class Menu
      * Exibe o HTML com o menu renderizado
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getMenu();
     }

--- a/src/HXPHP/System/Helpers/Menu/MenuData.php
+++ b/src/HXPHP/System/Helpers/Menu/MenuData.php
@@ -8,7 +8,7 @@ class MenuData
      * @param  string $key Titulo/Icone
      * @return object      Objeto com dados extraídos
      */
-    public static function get(string $key)
+    public static function get(string $key): \stdClass
     {
         $obj = new \stdClass;
 

--- a/src/HXPHP/System/Helpers/Menu/Render.php
+++ b/src/HXPHP/System/Helpers/Menu/Render.php
@@ -37,7 +37,7 @@ class Render
     /**
      * Renderiza o menu em HTML
      */
-    public function getHTML(string $role = 'default')
+    public function getHTML(string $role = 'default'): string
     {
         $menu_itens = ($this->menu_itens[$role]) ? $this->menu_itens[$role] : [];
         $menu_configs = $this->menu_configs;

--- a/src/HXPHP/System/Http/Request.php
+++ b/src/HXPHP/System/Http/Request.php
@@ -83,7 +83,7 @@ class Request
      * Define filtros/flags customizados (http://php.net/manual/en/filter.filters.sanitize.php)
      * @param array $custom_filters Array com nome do campo e seu respectivo filtro
      */
-    public function setCustomFilters(array $custom_filters = [])
+    public function setCustomFilters(array $custom_filters = []): array
     {
         return $this->custom_filters = $custom_filters;
     }
@@ -209,7 +209,7 @@ class Request
      * Verifica se o método da requisição é POST
      * @return boolean Status da verificação
      */
-    public function isPost()
+    public function isPost(): bool
     {
         return $this->getMethod('POST');
     }
@@ -218,7 +218,7 @@ class Request
      * Verifica se o método da requisição é GET
      * @return boolean Status da verificação
      */
-    public function isGet()
+    public function isGet(): bool
     {
         return $this->getMethod('GET');
     }
@@ -227,7 +227,7 @@ class Request
      * Verifica se o método da requisição é PUT
      * @return boolean Status da verificação
      */
-    public function isPut()
+    public function isPut(): bool
     {
         return $this->getMethod('PUT');
     }
@@ -236,7 +236,7 @@ class Request
      * Verifica se o método da requisição é HEAD
      * @return boolean Status da verificação
      */
-    public function isHead()
+    public function isHead(): bool
     {
         return $this->getMethod('HEAD');
     }
@@ -246,7 +246,7 @@ class Request
      *
      * @return boolean Inputs estão corretos ou não
      */
-    public function isValid()
+    public function isValid(): bool
     {
         $method = $this->getMethod();
 

--- a/src/HXPHP/System/Modules/Messages/LoadTemplate.php
+++ b/src/HXPHP/System/Modules/Messages/LoadTemplate.php
@@ -46,7 +46,7 @@ class LoadTemplate
      * Retorna o caminho do template
      * @return string
      */
-    public function getTemplatePath()
+    public function getTemplatePath(): string
     {
         return $this->file;
     }

--- a/src/HXPHP/System/Modules/Messages/Messages.php
+++ b/src/HXPHP/System/Modules/Messages/Messages.php
@@ -48,7 +48,7 @@ class Messages
      * Altera o bloco padrão
      * @param string $block
      */
-    public function setBlock(string $block)
+    public function setBlock(string $block): self
     {
         $this->block = $block;
         return $this;

--- a/src/HXPHP/System/Modules/Messages/Template.php
+++ b/src/HXPHP/System/Modules/Messages/Template.php
@@ -20,7 +20,7 @@ class Template
      * @param  array  $fields Fields e seus parâmetros para substituição
      * @return array
      */
-    public function getByCode(string $code, array $fields = [])
+    public function getByCode(string $code, array $fields = []): array
     {
         if ($this->content[$code]) {
             $output = $this->content[$code];

--- a/src/HXPHP/System/Services/Auth/Auth.php
+++ b/src/HXPHP/System/Services/Auth/Auth.php
@@ -124,7 +124,7 @@ class Auth
      * Verifica se o usuário está logado
      * @return boolean Status da autenticação
      */
-    public function login_check()
+    public function login_check(): bool
     {
         if ($this->storage->exists($this->subfolder . '_user_id') &&
                 $this->storage->exists($this->subfolder . '_username') &&
@@ -145,7 +145,7 @@ class Auth
      * Retorna a ID do usuário autenticado
      * @return integer ID do usuário
      */
-    public function getUserId()
+    public function getUserId(): int
     {
         return $this->storage->get($this->subfolder . '_user_id');
     }
@@ -154,7 +154,7 @@ class Auth
      * Retorna o role do usuário autenticado
      * @return string Role do usuário
      */
-    public function getUserRole()
+    public function getUserRole(): string
     {
         return $this->storage->get($this->subfolder . '_user_role');
     }

--- a/src/HXPHP/System/Services/Email/Email.php
+++ b/src/HXPHP/System/Services/Email/Email.php
@@ -5,7 +5,7 @@ class Email
 {
     private $from = null;
 
-    public function setFrom(array $from = [])
+    public function setFrom(array $from = []): self
     {
         $this->from = $from;
 
@@ -21,7 +21,7 @@ class Email
      * @param  bool   $accept_html Define se a mensagem será enviada em TXT ou HTML
      * @return bool             Status de envio e mensagem
      */
-    public function send(string $to, string $subject, string $message, array $from = [], bool $accept_html = true)
+    public function send(string $to, string $subject, string $message, array $from = [], bool $accept_html = true): bool
     {
         $to = strtolower($to);
         $subject = addslashes(trim($subject));

--- a/src/HXPHP/System/Storage/Cookie/Cookie.php
+++ b/src/HXPHP/System/Storage/Cookie/Cookie.php
@@ -9,7 +9,7 @@ class Cookie implements \HXPHP\System\Storage\StorageInterface
      * @param string $value Conteúdo do cookie
      * @param timestamp $time Tempo de duração do cookie
      */
-    public function set(string $name, string $value, int $time = 31556926)
+    public function set(string $name, string $value, int $time = 31556926): self
     {
         $cookieParams = session_get_cookie_params();
 
@@ -36,7 +36,7 @@ class Cookie implements \HXPHP\System\Storage\StorageInterface
      * @param  string  $name Nome do cookie
      * @return boolean       Status do processo
      */
-    public function exists(string $name)
+    public function exists(string $name): bool
     {
         return isset($_COOKIE[$name]);
     }

--- a/src/HXPHP/System/Storage/Session/Session.php
+++ b/src/HXPHP/System/Storage/Session/Session.php
@@ -14,7 +14,7 @@ class Session implements \HXPHP\System\Storage\StorageInterface
      * @param string $value Conteúdo da sessão
      * @param int $timeout  Tempo de expiração da sessão
      */
-    public function set(string $name, string $value, int $timeout = null)
+    public function set(string $name, string $value, int $timeout = null): self
     {
         $_SESSION[self::PREFIX][$name] = $value;
 
@@ -48,7 +48,7 @@ class Session implements \HXPHP\System\Storage\StorageInterface
      * @param  string  $name Nome da sessão
      * @return boolean       Status do processo
      */
-    public function exists(string $name)
+    public function exists(string $name): bool
     {
         return isset($_SESSION[self::PREFIX][$name]);
     }
@@ -58,7 +58,7 @@ class Session implements \HXPHP\System\Storage\StorageInterface
      * @param string $name   Nome da sessão
      * @return boolean       Sessão expirada ou não
      */
-    public function hasExpired(string $name)
+    public function hasExpired(string $name): bool
     {
         if (!$this->exists($name . '_timeout'))
             return false;
@@ -75,7 +75,7 @@ class Session implements \HXPHP\System\Storage\StorageInterface
      * @param string $name   Nome da sessão
      * @return date          Quantidade de tempo restante para o timeout
      */
-    public function getTimeLeftOf(string $name)
+    public function getTimeLeftOf(string $name): int
     {
         if ($this->hasExpired($name))
             return 0;

--- a/src/HXPHP/System/Storage/StorageInterface.php
+++ b/src/HXPHP/System/Storage/StorageInterface.php
@@ -23,7 +23,7 @@ interface StorageInterface
      * @param  string $name
      * @return boolean
      */
-    public function exists(string $name);
+    public function exists(string $name): bool;
     /**
      * Usar para apagar um indice do storage
      *

--- a/src/HXPHP/System/Tools.php
+++ b/src/HXPHP/System/Tools.php
@@ -32,7 +32,7 @@ class Tools
      * @param  string $salt     Código alfanumérico
      * @return array            Array com o SALT e a SENHA
      */
-    public static function hashHX(string $password, string $salt = null)
+    public static function hashHX(string $password, string $salt = null): array
     {
         if (!$salt)
             $salt = hash('sha512', uniqid(mt_rand(1, mt_getrandmax()), true));
@@ -50,7 +50,7 @@ class Tools
      * @param string $input     String que será convertida
      * @return string           String convertida
      */
-    public static function filteredName(string $input)
+    public static function filteredName(string $input): string
     {
         $input = explode('?', $input);
         $input = $input[0];
@@ -66,7 +66,7 @@ class Tools
         return str_replace(' ', '', ucwords(str_replace($find, $replace, $input)));
     }
 
-    public static function filteredFileName(string $input)
+    public static function filteredFileName(string $input): string
     {
         $input = trim($input);
 
@@ -184,7 +184,7 @@ class Tools
         return strtolower(str_replace(' ', '_', str_replace($find, $replace, $new)));
     }
 
-    public static function decamelize(string $cameled, string $sep = '-')
+    public static function decamelize(string $cameled, string $sep = '-'): string
     {
         return implode(
                 $sep, array_map(

--- a/src/HXPHP/System/View.php
+++ b/src/HXPHP/System/View.php
@@ -97,7 +97,7 @@ class View
      * Define o diretório das views parciais
      * @param string  $partialsDir  Diretório
      */
-    public function setPartialsDir(string $partialsDir, bool $overwrite = false)
+    public function setPartialsDir(string $partialsDir, bool $overwrite = false): self
     {
         $viewsDir = $this->configs->views->directory;
 
@@ -111,7 +111,7 @@ class View
      * Define o título da página
      * @param string  $title  Título da página
      */
-    public function setTitle(string $title)
+    public function setTitle(string $title): self
     {
         $this->title = $title;
         return $this;
@@ -121,7 +121,7 @@ class View
      * Define a pasta da view
      * @param string  $path  Caminho da View
      */
-    public function setPath(string $path, bool $overwrite = false)
+    public function setPath(string $path, bool $overwrite = false): self
     {
         $this->path = $overwrite === false ? $this->subfolder . $path : $path;
         return $this;
@@ -131,7 +131,7 @@ class View
      * Define se o arquivo é miolo (Inclusão de Cabeçalho e Rodapé) ou único
      * @param bool  $template  Template ON/OFF
      */
-    public function setTemplate(bool $template)
+    public function setTemplate(bool $template): self
     {
         $this->template = $template;
         return $this;
@@ -141,7 +141,7 @@ class View
      * Define o cabeçalho da view
      * @param string  $header  Cabeçalho da View
      */
-    public function setHeader(string $header, bool $overwrite = false)
+    public function setHeader(string $header, bool $overwrite = false): self
     {
         $this->header = $overwrite === false ? $this->subfolder . $header : $header;
         return $this;
@@ -151,7 +151,7 @@ class View
      * Define o arquivo da view
      * @param string  $file  Arquivo da View
      */
-    public function setFile(string $file)
+    public function setFile(string $file): self
     {
         $this->file = $file;
         return $this;
@@ -161,7 +161,7 @@ class View
      * Define o rodapé da view
      * @param string  $footer  Rodapé da View
      */
-    public function setFooter(string $footer, bool $overwrite = false)
+    public function setFooter(string $footer, bool $overwrite = false): self
     {
         $this->footer = $overwrite === false ? $this->subfolder . $footer : $footer;
         return $this;
@@ -171,7 +171,7 @@ class View
      * Define um conjunto de variáveis para a VIEW
      * @param array  $vars  Array com variáveis
      */
-    public function setVars(array $vars)
+    public function setVars(array $vars): self
     {
         $this->vars = array_merge($this->vars, $vars);
         return $this;
@@ -182,7 +182,7 @@ class View
      * @param string  $name  Nome do índice
      * @param string  $value  Valor
      */
-    public function setVar(string $name, $value)
+    public function setVar(string $name, $value): self
     {
         $this->vars[$name] = $value;
         return $this;
@@ -193,7 +193,7 @@ class View
      * @param string  $type  Tipo do arquivo
      * @param string|array  $assets  Arquivo Único | Array com os arquivos
      */
-    public function setAssets(string $type, $assets)
+    public function setAssets(string $type, $assets): self
     {
         (is_array($assets)) ?
                         $this->assets[$type] = array_merge($this->assets[$type], $assets) :
@@ -208,7 +208,7 @@ class View
      * @param  array  $custom_assets Links dos arquivos que serão incluídos
      * @return string                HTML formatado de acordo com o tipo de arquivo
      */
-    private function assets(string $type, array $custom_assets = [])
+    private function assets(string $type, array $custom_assets = []): string
     {
         $add_assets = '';
 
@@ -306,7 +306,7 @@ class View
         require($viewFile);
     }
 
-    public function getRelativeURL(string $URL, bool $controller = true)
+    public function getRelativeURL(string $URL, bool $controller = true): string
     {
         $path = $controller === true ? $this->path . DS : $this->subfolder;
 


### PR DESCRIPTION
Bom dia @brunosantoshx, tudo bom?

Na saga da nossa migração para o PHP 7, venho com esse PR adicionar os [tipos de retorno aos métodos](http://php.net/manual/pt_BR/functions.returning-values.php#functions.returning-values.type-declaration). Isto é de extrema segurança, eficiências em memória e importância ao Framework, já que este recurso trava que usuários mal intencionados retornem tipos de dados de sua preferência. Creio que algumas dúvidas surgirão com esse PR, portanto reuni-las, e pretendo soluciona-las abaixo:

- Porque nem todos os métodos possuem tipo de retorno?
  - [Métodos mágicos](http://php.net/manual/pt_BR/language.oop5.magic.php) não pode ser declarado esse tipo retorno;
  - Caso o método retorno dois ou mais [tipos](http://php.net/manual/pt_BR/functions.arguments.php#functions.arguments.type-declaration) de variável, não é possível informar o tipo de retorno;
  - Métodos com retorno `void` (ou vazio [entenda-se vazio como diferente de `null`]) foram [implementados apenas no PHP 7.1](https://secure.php.net/manual/pt_BR/migration71.new-features.php#migration71.new-features.void-functions), que será assunto de outros PRs;
  - [O método retornando ou não valores, recebendo ou não variáveis](https://secure.php.net/manual/pt_BR/migration71.new-features.php#migration71.new-features.nullable-types), também foi introduzido apenas no PHP 7.1

É isso, espero que aceite este PR, e que continuamos na nossa atualização com sucesso!

Abraços!
