### PR TITLE
Adição do Operador de coalescência nula

### DIFF
--- a/src/HXPHP/System/Helpers/Alert/Alert.php
+++ b/src/HXPHP/System/Helpers/Alert/Alert.php
@@ -26,7 +26,7 @@ class Alert
         if (count($alert) === 0)
             return null;
 
-        $alert[2] = !isset($alert[2]) ? '' : $alert[2];
+        $alert[2] = $alert[2] ?? '';
 
         list($style, $title, $message) = $alert;
 


### PR DESCRIPTION
Olá @brunosantoshx, tudo bom?

Trago neste PR, um novo operador do PHP 7, o [operador de coalescência nula](http://php.net/manual/pt_BR/language.operators.comparison.php#language.operators.comparison.coalesce). Ele é um alias para antigas verificações que fazíamos com a função `isset()`. No framework puro, encontrei apenas um caso na classe Helpers\Alert, porém, em produção, podemos substituir todas as verificações de menus e alerts por este operador. Exemplo:
```php
//Antes do PHP 7
echo isset($this->alert) ? $this->alert : '';

//Depois do PHP 7
echo $this->alert ?? '';
```

Espero que goste dessa contribuição, e vamos em frente nesta migração!
Abraços