### PR TITLE
Rearanjo das opções de início de sessão PHP 7

### DIFF
--- a/src/HXPHP/System/Services/StartSession/StartSession.php
+++ b/src/HXPHP/System/Services/StartSession/StartSession.php
@@ -10,14 +10,14 @@ class StartSession
      */
     static function sec_session_start(bool $regenerate = false)
     {
-        ini_set('session.use_only_cookies', 1);
-
         $cookieParams = session_get_cookie_params();
 
         session_set_cookie_params($cookieParams["lifetime"], $cookieParams["path"], $cookieParams["domain"], false, true);
 
-        session_name('sec_session_id');
-        session_start();
+        session_start([
+            'name' => 'sec_session_id',
+            'use_only_cookies' => 1
+        ]);
 
         if ($regenerate)
             session_regenerate_id(true);


### PR DESCRIPTION
Boa tarde @brunosantoshx 

Venho com mais um PR para migrarmos ao PHP 7 com sucesso. Desta vez, atualizei as opções de sessões com uma [nova funcionalidade](http://php.net/manual/pt_BR/migration70.new-features.php#migration70.new-features.session-options) da função `session_start()` que permite um `array` de opções agora.

E gostaria de tirar uma dúvida: para que serve a função `session_regenerate_id()` no final do método `sec_session_start()`? Gostaria de saber, pois estive pensando em uma melhoria desta classe: adicionarmos um `return` com um `boolean` do resultado da função `session_start()`, para melhor controle de erros do HXPHP.

Aguardo seus comentários, abraços!