### PR TITLE
Agrupamento declaração use e remoção de alias redundantes

### DIFF
--- a/src/HXPHP/System/App.php
+++ b/src/HXPHP/System/App.php
@@ -1,7 +1,10 @@
 <?php
 namespace HXPHP\System;
 
-use HXPHP\System\Http as Http;
+use HXPHP\System\{
+    Http,
+    Configs\Config
+};
 
 class App
 {
@@ -26,7 +29,7 @@ class App
     /**
      * Método Construtor
      */
-    public function __construct(Configs\Config $configs)
+    public function __construct(Config $configs)
     {
         $this->configs = $configs;
         $this->request = new Http\Request($configs->baseURI, $configs->global->controllers->directory);

--- a/src/HXPHP/System/Configs/Environments/EnvironmentDevelopment.php
+++ b/src/HXPHP/System/Configs/Environments/EnvironmentDevelopment.php
@@ -1,7 +1,7 @@
 <?php
 namespace HXPHP\System\Configs\Environments;
 
-use HXPHP\System\Configs as Configs;
+use HXPHP\System\Configs;
 
 class EnvironmentDevelopment extends Configs\AbstractEnvironment
 {

--- a/src/HXPHP/System/Configs/Environments/EnvironmentProduction.php
+++ b/src/HXPHP/System/Configs/Environments/EnvironmentProduction.php
@@ -1,7 +1,7 @@
 <?php
 namespace HXPHP\System\Configs\Environments;
 
-use HXPHP\System\Configs as Configs;
+use HXPHP\System\Configs;
 
 class EnvironmentProduction extends Configs\AbstractEnvironment
 {

--- a/src/HXPHP/System/Configs/Environments/EnvironmentTests.php
+++ b/src/HXPHP/System/Configs/Environments/EnvironmentTests.php
@@ -1,7 +1,7 @@
 <?php
 namespace HXPHP\System\Configs\Environments;
 
-use HXPHP\System\Configs as Configs;
+use HXPHP\System\Configs;
 
 class EnvironmentTests extends Configs\AbstractEnvironment
 {

--- a/src/HXPHP/System/Configs/GlobalConfig.php
+++ b/src/HXPHP/System/Configs/GlobalConfig.php
@@ -1,7 +1,7 @@
 <?php
 namespace HXPHP\System\Configs;
 
-use HXPHP\System\Http\Request as Request;
+use HXPHP\System\Http\Request;
 
 class GlobalConfig
 {

--- a/src/HXPHP/System/Controller.php
+++ b/src/HXPHP/System/Controller.php
@@ -1,7 +1,10 @@
 <?php
 namespace HXPHP\System;
 
-use HXPHP\System\Http as Http;
+use HXPHP\System\{
+    Http,
+    Configs\Config
+};
 
 class Controller
 {
@@ -29,7 +32,7 @@ class Controller
      */
     public $view;
 
-    public function __construct(Configs\Config $configs = null)
+    public function __construct(Config $configs = null)
     {
         //Injeção da VIEW
         $this->view = new View;
@@ -44,7 +47,7 @@ class Controller
      * @param  Config $configs Objeto com as configurações da aplicação
      * @return object
      */
-    public function setConfigs(Configs\Config $configs): self
+    public function setConfigs(Config $configs): self
     {
         //Injeção das dependências
         $this->configs = $configs;

--- a/src/HXPHP/System/Helpers/Alert/Alert.php
+++ b/src/HXPHP/System/Helpers/Alert/Alert.php
@@ -1,7 +1,7 @@
 <?php
 namespace HXPHP\System\Helpers\Alert;
 
-use HXPHP\System\Storage as Storage;
+use HXPHP\System\Storage;
 
 class Alert
 {

--- a/src/HXPHP/System/Helpers/Menu/Menu.php
+++ b/src/HXPHP/System/Helpers/Menu/Menu.php
@@ -1,8 +1,10 @@
 <?php
 namespace HXPHP\System\Helpers\Menu;
 
-use HXPHP\System\Configs\Config;
-use HXPHP\System\Http\Request;
+use HXPHP\System\{
+    Http\Request,
+    Configs\Config
+};
 
 class Menu
 {

--- a/src/HXPHP/System/Modules/Messages/LoadTemplate.php
+++ b/src/HXPHP/System/Modules/Messages/LoadTemplate.php
@@ -1,7 +1,7 @@
 <?php
 namespace HXPHP\System\Modules\Messages;
 
-use HXPHP\System\Tools as Tools;
+use HXPHP\System\Tools;
 
 class LoadTemplate
 {

--- a/src/HXPHP/System/Services/Auth/Auth.php
+++ b/src/HXPHP/System/Services/Auth/Auth.php
@@ -1,8 +1,10 @@
 <?php
 namespace HXPHP\System\Services\Auth;
 
-use HXPHP\System\Storage as Storage;
-use HXPHP\System\Http as Http;
+use HXPHP\System\{
+    Http,
+    Storage
+};
 
 class Auth
 {


### PR DESCRIPTION
Bom dia @brunosantoshx, como vamos?

Bem, chegamos ao último PR de migração ao PHP 7. Trago nesse, a funcionalidade [de agrupamento das declarações `use` ](http://php.net/manual/pt_BR/language.namespaces.importing.php#language.namespaces.importing.group), algo que acredito ser de extrema organização quando o projeto começa a ganhar uma certa robustidade. 

Aproveitei também este PR para remover alguns _aliasing_ redundantes (O 1º exemplo [desta página](http://php.net/manual/pt_BR/language.namespaces.importing.php#language.namespaces.importing), na 3ª linha mostra o que quero dizer).

Bem espero que goste, e que agora venha mais migrações para versões futuras do PHP e novas funcionalidades para este framework.

Abraços!