### PR TITLE
Remodelagem do método server() na classe Request evitando FASTCGI

### DIFF
--- a/src/HXPHP/System/Configs/DefineEnvironment.php
+++ b/src/HXPHP/System/Configs/DefineEnvironment.php
@@ -1,6 +1,8 @@
 <?php
 namespace HXPHP\System\Configs;
 
+use HXPHP\System\Http\Request;
+
 class DefineEnvironment
 {
     private $currentEnviroment;
@@ -8,7 +10,8 @@ class DefineEnvironment
     public function __construct()
     {
         //Servidor atual
-        $server_name = $_SERVER['SERVER_NAME'];
+        $request = new Request();
+        $https = $request->server('SERVER_NAME');
 
         //Estanciamento da pasta Environments
         $enviroments = new \FilesystemIterator(__DIR__ . '/Environments', \FilesystemIterator::SKIP_DOTS);

--- a/src/HXPHP/System/Http/Request.php
+++ b/src/HXPHP/System/Http/Request.php
@@ -164,11 +164,11 @@ class Request
         if (!$name)
             return $server;
 
-        if (!isset($server[$name]) && !isset($_SERVER[$name]))
-            return null;
-
-        if (isset($_SERVER[$name]))
+        if (is_null($server[$name]))
             return $_SERVER[$name];
+
+        if (!isset($server[$name]))
+            return null;
 
         return $server[$name];
     }


### PR DESCRIPTION
Olá @brunosantoshx , boa tarde.

Lembro no PR #83 você ter comentado sobre problemas da utilização do método `server()`. devido a uma proteção `FASTCGI`. Com essas mudanças que fiz, e testes em produção com essa proteção, obtive resultados com sucesso.

Já realizei também o uso dele na classe `DefineEnvironment`.

Abraços.