### PR TITLE
Atualização do composer autoload para a PSR-4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Created by https://www.gitignore.io/api/osx,sass,less,macos,linux,bower,windows,eclipse,netbeans,composer,phpstorm,notepadpp,dreamweaver,aptanastudio,visualstudio,visualstudiocode
 
+composer.lock
+
 ### AptanaStudio ###
 
 .metadata

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         }
     ],
     "autoload": {
-        "psr-0": {
-            "": ["src/"]
+        "psr-4":{
+            "HXPHP\\": "src/HXPHP"
         }
     },
     "config": {


### PR DESCRIPTION
O composer autoload PSR-0 foi depreciado, a atualização para a PSR-4 é o mais recomendado atualmente.