### PR TITLE
Uso do Apache Vhost

### DIFF
--- a/src/HXPHP/System/Configs/DefineEnvironment.php
+++ b/src/HXPHP/System/Configs/DefineEnvironment.php
@@ -8,9 +8,10 @@ class DefineEnvironment
     public function __construct()
     {
         $server_name = $_SERVER['SERVER_NAME'];
+        $server_addr = $_SERVER['SERVER_ADDR'];
         $development = new Environments\EnvironmentDevelopment;
 
-        (in_array($server_name, $development->servers)) ?
+        (in_array($server_addr || $server_name, $development->servers)) ?
                         $this->currentEnviroment = 'development' :
                         $this->currentEnviroment = 'production';
 

--- a/src/HXPHP/System/Configs/Environments/EnvironmentDevelopment.php
+++ b/src/HXPHP/System/Configs/Environments/EnvironmentDevelopment.php
@@ -12,7 +12,8 @@ class EnvironmentDevelopment extends Configs\AbstractEnvironment
         parent::__construct();
         $this->servers = [
             'localhost',
-            '127.0.0.1'
+            '127.0.0.1',
+            '::1'
         ];
     }
 }


### PR DESCRIPTION
Tive problemas ao usar o HXPHP em vhost, devido ao framework considerar que o vhost é um servidor real, então coloquei para usar o IP como base comparação para decidir em qual enviroment está sendo executado.

Adicionado a configuração para considerar o uso de Vhosts como local de desenvolvimento